### PR TITLE
Switch the configuration from Dahll to Yaml

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -42,12 +42,12 @@ Library
                       , file-embed
                       , temporary
                       , unix-compat
+                      , unordered-containers
+                      , yaml
                       , cryptohash-sha1
                       , bytestring
                       , base16-bytestring
-                      , dhall <= 1.20.1
                       , text
-                      , lens-family-core
   if impl(ghc < 8.2)
     Build-Depends:      ghc-boot
 


### PR DESCRIPTION
Note that this patch is completely untested (other than it builds), since you didn't seem to have any Dahll test files sitting around. I went for a pretty simple encoding, so `cabal:` or `cabal: {component: lib}` are sufficient. It probably doesn't produce fantastic error messages.