### PR TITLE
Change config filename from hie.dhall to hie.yaml

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -59,11 +59,12 @@ implicitConfig fp =
 
 dhallConfig :: FilePath -> MaybeT IO (CradleConfig, FilePath)
 dhallConfig fp = do
-  wdir <- findFileUpwards ("hie.dhall" ==) fp
-  cfg  <- liftIO $ readConfig (wdir </> "hie.dhall")
+  wdir <- findFileUpwards (configFileName ==) fp
+  cfg  <- liftIO $ readConfig (wdir </> configFileName)
   return (cradle cfg, wdir)
 
-
+configFileName :: FilePath
+configFileName = "hie.yaml"
 
 
 ---------------------------------------------------------------


### PR DESCRIPTION
Now that the file is expected to be a yaml file it doesn’t make much
sense to call it hie.dhall.