### PR TITLE
A couple of fixes needed to use hie-core on Darcs

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -138,14 +138,19 @@ processCabalWrapperArgs args =
             in trace dir $ Just final_args
         _ -> Nothing
 
-cabalAction :: FilePath -> Maybe String -> FilePath -> IO (ExitCode, String, [String])
-cabalAction work_dir mc _fp = do
+getCabalWrapperTool :: IO FilePath
+getCabalWrapperTool = do
   wrapper_fp <- writeSystemTempFile "wrapper.bat" $
     if isWindows then cabalWrapperBat else cabalWrapper
   -- TODO: This isn't portable for windows
   setFileMode wrapper_fp accessModes
   check <- readFile wrapper_fp
   traceM check
+  return wrapper_fp
+
+cabalAction :: FilePath -> Maybe String -> FilePath -> IO (ExitCode, String, [String])
+cabalAction work_dir mc _fp = do
+  wrapper_fp <- getCabalWrapperTool
   let cab_args = ["v2-repl", "-v0", "--with-compiler", wrapper_fp]
                   ++ [component_name | Just component_name <- [mc]]
   (ex, args, stde) <-

--- a/wrappers/cabal.bat
+++ b/wrappers/cabal.bat
@@ -1,7 +1,0 @@
-@ECHO OFF
-IF "%i" == "--interactive" (
-  ECHO %CD%
-  ECHO %*
-) ELSE (
-  ghc %*
-)

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -1,0 +1,18 @@
+module Main (main) where
+
+import System.Directory (getCurrentDirectory)
+import System.Environment (getArgs)
+import System.Exit (exitWith)
+import System.Process (spawnProcess, waitForProcess)
+
+main = do
+  args <- getArgs
+  case args of
+    "--interactive":_ -> do
+      getCurrentDirectory >>= putStrLn
+      -- note this probably breaks if paths have spaces in
+      putStrLn $ unwords args
+    _ -> do
+      ph <- spawnProcess "ghc" args
+      code <- waitForProcess ph
+      exitWith code


### PR DESCRIPTION
Darcs is big enough that the ghc command-line is about 11K characters which blows the limit for
Windows batch files. We discussed this a bit in person at Munihac and decided this was the least
invasive solution.

Also needed to lift a bit more code from ghc's Main.hs to support recognising '.o' arguments coming
from C source code and passing them to the right place.