### PR TITLE
Refactor project into specifics for GHC and Compiler Flags

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -6,7 +6,7 @@ import Config (cProjectVersion)
 
 import Control.Exception (Exception, Handler(..), ErrorCall(..))
 import qualified Control.Exception as E
-import           Control.Monad                  ( forM )
+import Control.Monad ( forM )
 import Data.Typeable (Typeable)
 import Data.Version (showVersion)
 import System.Directory (getCurrentDirectory)
@@ -69,7 +69,7 @@ main = flip E.catches handlers $ do
         res <- forM remainingArgs $ \fp -> do
                 res <- getCompilerOptions fp cradle
                 case res of
-                    Left err -> return $ "Failed to show flags for: " ++ show err
+                    Left err -> return $ "Failed to show flags for \"" ++ fp ++ "\": " ++ show err
                     Right opts -> return $ "CompilerOptions: " ++ show (ghcOptions opts)
         return (unlines res)
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -15,7 +15,7 @@ import System.IO (hPutStr, hPutStrLn, stdout, stderr, hSetEncoding, utf8)
 
 import HIE.Bios
 import HIE.Bios.Types
-import HIE.Bios.Check
+import HIE.Bios.Ghc.Check
 import HIE.Bios.Debug
 import Paths_hie_bios
 

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -14,24 +14,25 @@ Build-Type:             Simple
 Extra-Source-Files:     ChangeLog
                         wrappers/bazel
                         wrappers/cabal
-                        wrappers/cabal.bat
+                        wrappers/cabal.hs
 
 Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
   HS-Source-Dirs:       src
   Exposed-Modules:      HIE.Bios
-                        HIE.Bios.Check
+                        HIE.Bios.Config
                         HIE.Bios.Cradle
                         HIE.Bios.Debug
-                        HIE.Bios.GHCApi
-                        HIE.Bios.Gap
-                        HIE.Bios.Doc
-                        HIE.Bios.Load
-                        HIE.Bios.Logger
                         HIE.Bios.Types
-                        HIE.Bios.Things
-                        HIE.Bios.Config
+                        HIE.Bios.Ghc.Api
+                        HIE.Bios.Ghc.Check
+                        HIE.Bios.Ghc.Doc
+                        HIE.Bios.Ghc.Gap
+                        HIE.Bios.Ghc.Load
+                        HIE.Bios.Ghc.Logger
+                        HIE.Bios.Ghc.Things
+                        HIE.Bios.Ghc.Types
   Build-Depends:
                         base >= 4.8 && < 5,
                         base16-bytestring    >= 0.1.1 && < 0.2,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -23,6 +23,7 @@ Library
   Exposed-Modules:      HIE.Bios
                         HIE.Bios.Config
                         HIE.Bios.Cradle
+                        HIE.Bios.Environment
                         HIE.Bios.Debug
                         HIE.Bios.Flags
                         HIE.Bios.Types
@@ -49,7 +50,7 @@ Library
                         file-embed           >= 0.0.11 && < 0.1,
                         ghc                  >= 8.4.1 && < 8.7,
                         transformers         >= 0.5.5 && < 0.6,
-                        temporary            >= 1.3 && < 1.4,
+                        temporary            >= 1.2 && < 1.4,
                         text                 >= 1.2.3 && < 1.3,
                         unix-compat          >= 0.5.2 && < 0.6,
                         unordered-containers >= 0.2.10 && < 0.3,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -24,6 +24,7 @@ Library
                         HIE.Bios.Config
                         HIE.Bios.Cradle
                         HIE.Bios.Debug
+                        HIE.Bios.Flags
                         HIE.Bios.Types
                         HIE.Bios.Ghc.Api
                         HIE.Bios.Ghc.Check

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -12,9 +12,11 @@ module HIE.Bios (
   , loadFileWithMessage
   -- * Eliminate a session to IO
   , withGhcT
+  , getCompilerOptions
   ) where
 
 import HIE.Bios.Cradle
 import HIE.Bios.Types
+import HIE.Bios.Flags
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Load

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -5,18 +5,14 @@ module HIE.Bios (
     Cradle(..)
   , findCradle
   , defaultCradle
-  , initializeFlagsWithCradle
-  , initializeFlagsWithCradleWithMessage
-  -- * Load a module into a session
-  , loadFile
-  , loadFileWithMessage
-  -- * Eliminate a session to IO
-  , withGhcT
+  -- * Compiler Options
+  , CompilerOptions(..)
   , getCompilerOptions
+  -- * Init session
+  , initSession
   ) where
 
 import HIE.Bios.Cradle
 import HIE.Bios.Types
 import HIE.Bios.Flags
-import HIE.Bios.Ghc.Api
-import HIE.Bios.Ghc.Load
+import HIE.Bios.Environment

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -16,5 +16,5 @@ module HIE.Bios (
 
 import HIE.Bios.Cradle
 import HIE.Bios.Types
-import HIE.Bios.GHCApi
-import HIE.Bios.Load
+import HIE.Bios.Ghc.Api
+import HIE.Bios.Ghc.Load

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -96,7 +96,7 @@ directCradle wdir args =
 -- | Find a cradle by finding an executable `hie-bios` file which will
 -- be executed to find the correct GHC options to use.
 biosCradle :: FilePath -> FilePath -> Cradle
-biosCradle wdir bios = do
+biosCradle wdir bios =
   Cradle {
       cradleRootDir    = wdir
     , cradleOptsProg   = CradleAction "bios" (biosAction wdir bios)
@@ -240,7 +240,7 @@ rulesHaskellWorkDir fp =
   findFileUpwards (== "WORKSPACE") fp
 
 rulesHaskellCradle :: FilePath -> Cradle
-rulesHaskellCradle wdir = do
+rulesHaskellCradle wdir =
   Cradle {
       cradleRootDir  = wdir
     , cradleOptsProg   = CradleAction "bazel" (rulesHaskellAction wdir)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -21,7 +21,6 @@ import Data.FileEmbed
 import System.IO.Temp
 import Data.List
 
-import Debug.Trace
 import System.PosixCompat.Files
 
 ----------------------------------------------------------------
@@ -118,7 +117,7 @@ biosAction _wdir bios fp = do
 -- yet.
 
 cabalCradle :: FilePath -> Maybe String -> Cradle
-cabalCradle wdir mc = do
+cabalCradle wdir mc =
   Cradle {
       cradleRootDir    = wdir
     , cradleOptsProg   = CradleAction "cabal" (cabalAction wdir mc)
@@ -135,7 +134,7 @@ processCabalWrapperArgs args =
     case lines args of
         [dir, ghc_args] ->
             let final_args = removeInteractive $ map (fixImportDirs dir) (words ghc_args)
-            in trace dir $ Just final_args
+            in Just final_args
         _ -> Nothing
 
 -- generate a fake GHC that can be passed to cabal
@@ -205,8 +204,9 @@ stackAction work_dir fp = do
   wrapper_fp <- writeSystemTempFile "wrapper" stackWrapper
   -- TODO: This isn't portable for windows
   setFileMode wrapper_fp accessModes
-  check <- readFile wrapper_fp
-  traceM check
+  -- TODO: this is for debugging
+  -- check <- readFile wrapper_fp
+  -- traceM check
   (ex1, args, stde) <-
       withCurrentDirectory work_dir (readProcessWithExitCode "stack" ["repl", "--silent", "--no-load", "--with-ghc", wrapper_fp, fp ] [])
   (ex2, pkg_args, stdr) <-
@@ -255,10 +255,7 @@ rulesHaskellAction work_dir fp = do
   wrapper_fp <- writeSystemTempFile "wrapper" bazelCommand
   -- TODO: This isn't portable for windows
   setFileMode wrapper_fp accessModes
-  check <- readFile wrapper_fp
-  traceM check
   let rel_path = makeRelative work_dir fp
-  traceM rel_path
   (ex, args, stde) <-
       withCurrentDirectory work_dir (readProcessWithExitCode wrapper_fp [rel_path] [])
   let args'  = filter (/= '\'') args

--- a/src/HIE/Bios/Debug.hs
+++ b/src/HIE/Bios/Debug.hs
@@ -1,10 +1,10 @@
 module HIE.Bios.Debug (debugInfo, rootInfo) where
 
-import CoreMonad (liftIO)
+import Control.Monad.IO.Class (liftIO)
 
 import Data.Maybe (fromMaybe)
 
-import HIE.Bios.GHCApi
+import HIE.Bios.Ghc.Api
 import HIE.Bios.Types
 
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE RecordWildCards, CPP #-}
+module HIE.Bios.Environment (initSession, getSystemLibDir, addCmdOpts, getDynamicFlags) where
+
+import CoreMonad (liftIO)
+import GHC (DynFlags(..), GhcLink(..), HscTarget(..), GhcMonad)
+import qualified GHC as G
+import qualified DriverPhases as G
+import qualified Util as G
+import DynFlags
+
+import Control.Monad (void, when)
+
+import System.Process (readProcess)
+import System.Directory
+import System.FilePath
+
+import qualified Crypto.Hash.SHA1 as H
+import qualified Data.ByteString.Char8 as B
+import Data.ByteString.Base16
+import Data.List
+
+import HIE.Bios.Types
+
+initSession :: (GhcMonad m)
+    => CompilerOptions
+    -> m [G.Target]
+initSession  CompilerOptions {..} = do
+    df <- G.getSessionDynFlags
+    -- traceShowM (length ghcOptions)
+
+    let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init (map B.pack ghcOptions)
+    fp <- liftIO $ getCacheDir opts_hash
+    -- For now, clear the cache initially rather than persist it across
+    -- sessions
+    liftIO $ clearInterfaceCache opts_hash
+    (df', targets) <- addCmdOpts ghcOptions df
+    void $ G.setSessionDynFlags
+        (disableOptimisation
+        $ setIgnoreInterfacePragmas
+        $ resetPackageDb
+        -- $ ignorePackageEnv
+        $ writeInterfaceFiles (Just fp)
+        $ setVerbosity 0
+
+        $ setLinkerOptions df'
+        )
+    G.setLogAction (\_df _wr _s _ss _pp _m -> return ())
+#if __GLASGOW_HASKELL__ < 806
+        (\_df -> return ())
+#endif
+
+    return targets
+
+----------------------------------------------------------------
+
+-- | Obtaining the directory for system libraries.
+getSystemLibDir :: IO (Maybe FilePath)
+getSystemLibDir = do
+    res <- readProcess "ghc" ["--print-libdir"] []
+    return $ case res of
+        ""   -> Nothing
+        dirn -> Just (init dirn)
+
+----------------------------------------------------------------
+
+
+cacheDir :: String
+cacheDir = "haskell-ide-engine"
+
+clearInterfaceCache :: FilePath -> IO ()
+clearInterfaceCache fp = do
+  cd <- getCacheDir fp
+  res <- doesPathExist cd
+  when res (removeDirectoryRecursive cd)
+
+getCacheDir :: FilePath -> IO FilePath
+getCacheDir fp = getXdgDirectory XdgCache (cacheDir </> fp)
+
+----------------------------------------------------------------
+
+-- we don't want to generate object code so we compile to bytecode
+-- (HscInterpreted) which implies LinkInMemory
+-- HscInterpreted
+setLinkerOptions :: DynFlags -> DynFlags
+setLinkerOptions df = df {
+    ghcLink   = LinkInMemory
+  , hscTarget = HscNothing
+  , ghcMode = CompManager
+  }
+
+resetPackageDb :: DynFlags -> DynFlags
+resetPackageDb df = df { pkgDatabase = Nothing }
+
+--ignorePackageEnv :: DynFlags -> DynFlags
+--ignorePackageEnv df = df { packageEnv = Just "-" }
+
+setIgnoreInterfacePragmas :: DynFlags -> DynFlags
+setIgnoreInterfacePragmas df = gopt_set df Opt_IgnoreInterfacePragmas
+
+setVerbosity :: Int -> DynFlags -> DynFlags
+setVerbosity n df = df { verbosity = n }
+
+writeInterfaceFiles :: Maybe FilePath -> DynFlags -> DynFlags
+writeInterfaceFiles Nothing df = df
+writeInterfaceFiles (Just hi_dir) df = setHiDir hi_dir (gopt_set df Opt_WriteInterface)
+
+setHiDir :: FilePath -> DynFlags -> DynFlags
+setHiDir f d = d { hiDir      = Just f}
+
+
+addCmdOpts :: (GhcMonad m)
+           => [String] -> DynFlags -> m (DynFlags, [G.Target])
+addCmdOpts cmdOpts df1 = do
+  (df2, leftovers, _warns) <- G.parseDynamicFlags df1 (map G.noLoc cmdOpts)
+  -- TODO: remove this trace
+  -- What about warnings?
+  -- traceShowM (map G.unLoc leftovers, length warns)
+
+  let
+     -- To simplify the handling of filepaths, we normalise all filepaths right
+     -- away. Note the asymmetry of FilePath.normalise:
+     --    Linux:   p/q -> p/q; p\q -> p\q
+     --    Windows: p/q -> p\q; p\q -> p\q
+     -- #12674: Filenames starting with a hypen get normalised from ./-foo.hs
+     -- to -foo.hs. We have to re-prepend the current directory.
+    normalise_hyp fp
+        | strt_dot_sl && "-" `isPrefixOf` nfp = cur_dir ++ nfp
+        | otherwise                           = nfp
+        where
+#if defined(mingw32_HOST_OS)
+          strt_dot_sl = "./" `isPrefixOf` fp || ".\\" `isPrefixOf` fp
+#else
+          strt_dot_sl = "./" `isPrefixOf` fp
+#endif
+          cur_dir = '.' : [pathSeparator]
+          nfp = normalise fp
+    normal_fileish_paths = map (normalise_hyp . G.unLoc) leftovers
+  let
+   (srcs, objs) = partition_args normal_fileish_paths [] []
+   df3 = df2 { ldInputs = map (FileOption "") objs ++ ldInputs df2 }
+  ts <- mapM (uncurry G.guessTarget) srcs
+  return (df3, ts)
+    -- TODO: Need to handle these as well
+    -- Ideally it requires refactoring to work in GHCi monad rather than
+    -- Ghc monad and then can just use newDynFlags.
+    {-
+    liftIO $ G.handleFlagWarnings idflags1 warns
+    when (not $ null leftovers)
+        (throwGhcException . CmdLineError
+         $ "Some flags have not been recognized: "
+         ++ (concat . intersperse ", " $ map unLoc leftovers))
+    when (interactive_only && packageFlagsChanged idflags1 idflags0) $ do
+       liftIO $ hPutStrLn stderr "cannot set package flags with :seti; use :set"
+    -}
+
+----------------------------------------------------------------
+
+-- | Return the 'DynFlags' currently in use in the GHC session.
+getDynamicFlags :: IO DynFlags
+getDynamicFlags = do
+    mlibdir <- getSystemLibDir
+    G.runGhc mlibdir G.getSessionDynFlags
+
+
+-- partition_args, along with some of the other code in this file,
+-- was copied from ghc/Main.hs
+-- -----------------------------------------------------------------------------
+-- Splitting arguments into source files and object files.  This is where we
+-- interpret the -x <suffix> option, and attach a (Maybe Phase) to each source
+-- file indicating the phase specified by the -x option in force, if any.
+partition_args :: [String] -> [(String, Maybe G.Phase)] -> [String]
+               -> ([(String, Maybe G.Phase)], [String])
+partition_args [] srcs objs = (reverse srcs, reverse objs)
+partition_args ("-x":suff:args) srcs objs
+  | "none" <- suff      = partition_args args srcs objs
+  | G.StopLn <- phase     = partition_args args srcs (slurp ++ objs)
+  | otherwise           = partition_args rest (these_srcs ++ srcs) objs
+        where phase = G.startPhase suff
+              (slurp,rest) = break (== "-x") args
+              these_srcs = zip slurp (repeat (Just phase))
+partition_args (arg:args) srcs objs
+  | looks_like_an_input arg = partition_args args ((arg,Nothing):srcs) objs
+  | otherwise               = partition_args args srcs (arg:objs)
+
+    {-
+      We split out the object files (.o, .dll) and add them
+      to ldInputs for use by the linker.
+      The following things should be considered compilation manager inputs:
+       - haskell source files (strings ending in .hs, .lhs or other
+         haskellish extension),
+       - module names (not forgetting hierarchical module names),
+       - things beginning with '-' are flags that were not recognised by
+         the flag parser, and we want them to generate errors later in
+         checkOptions, so we class them as source files (#5921)
+       - and finally we consider everything without an extension to be
+         a comp manager input, as shorthand for a .hs or .lhs filename.
+      Everything else is considered to be a linker object, and passed
+      straight through to the linker.
+    -}
+looks_like_an_input :: String -> Bool
+looks_like_an_input m =  G.isSourceFilename m
+                      || G.looksLikeModuleName m
+                      || "-" `isPrefixOf` m
+                      || not (hasExtension m)
+
+-- --------------------------------------------------------
+
+disableOptimisation :: DynFlags -> DynFlags
+disableOptimisation df = updOptLevel 0 df

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -1,0 +1,28 @@
+module HIE.Bios.Flags where
+
+
+-- | Initialize the 'DynFlags' relating to the compilation of a single
+-- file or GHC session according to the 'Cradle' and 'Options'
+-- provided.
+getCompilerOptions ::
+    FilePath -- The file we are loading it because of
+    -> Cradle
+    -> IO CompilerOptions
+getCompilerOptions fp cradle = do
+  (ex, err, ghcOpts) <- liftIO $ getOptions (cradleOptsProg cradle) fp
+  G.pprTrace "res" (G.text (show (ex, err, ghcOpts, fp))) (return ())
+  case ex of
+    ExitFailure _ -> throwCradleError err
+    _ -> return ()
+  let compOpts = CompilerOptions ghcOpts
+  liftIO $ hPrint stderr ghcOpts
+  return compOpts
+
+data CradleError = CradleError String deriving (Show)
+
+instance Exception CradleError where
+
+throwCradleError :: GhcMonad m => String -> m ()
+throwCradleError = liftIO . throwIO . CradleError
+
+----------------------------------------------------------------

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -70,7 +70,7 @@ initializeFlagsWithCradle ::
     => FilePath -- The file we are loading it because of
     -> Cradle
     -> m ()
-initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage Nothing
+initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage (Just G.batchMsg)
 
 initializeFlagsWithCradleWithMessage ::
   GhcMonad m

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -13,47 +13,29 @@ module HIE.Bios.Ghc.Api (
   , setNoWarningFlags
   , setAllWarningFlags
   , setDeferTypeErrors
-  , CradleError(..)
   ) where
 
 import CoreMonad (liftIO)
-import Exception (ghandle, SomeException(..), ExceptionMonad(..), throwIO, Exception(..))
-import GHC (Ghc, DynFlags(..), GhcLink(..), HscTarget(..), LoadHowMuch(..), GhcMonad, GhcT)
+import Exception (ghandle, SomeException(..), ExceptionMonad(..), throwIO)
+import GHC (Ghc, LoadHowMuch(..), GhcMonad, GhcT)
+import DynFlags
+
 import qualified GHC as G
-import qualified DriverPhases as G
-import qualified Outputable as G
 import qualified MonadUtils as G
 import qualified HscMain as G
 import qualified GhcMake as G
-import qualified Util as G
-import DynFlags
 
-import Control.Monad (void, when)
-import System.Exit (exitSuccess, ExitCode(..))
+import Control.Monad (void)
+import System.Exit (exitSuccess)
 import System.IO (hPutStr, hPrint, stderr)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Process (readProcess)
-
-import System.Directory
-import System.FilePath
 
 import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Types
-import Debug.Trace
-import qualified Crypto.Hash.SHA1 as H
-import qualified Data.ByteString.Char8 as B
-import Data.ByteString.Base16
-import Data.List
+import HIE.Bios.Environment
+import HIE.Bios.Flags
 
-----------------------------------------------------------------
 
--- | Obtaining the directory for system libraries.
-getSystemLibDir :: IO (Maybe FilePath)
-getSystemLibDir = do
-    res <- readProcess "ghc" ["--print-libdir"] []
-    return $ case res of
-        ""   -> Nothing
-        dirn -> Just (init dirn)
 
 ----------------------------------------------------------------
 
@@ -81,166 +63,39 @@ withGhcT body = do
 
 ----------------------------------------------------------------
 
-data Build = CabalPkg | SingleFile deriving Eq
+
 
 initializeFlagsWithCradle ::
-        (GhcMonad m)
-        => FilePath -- The file we are loading it because of
-        -> Cradle
-        -> m ()
-initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage (Just G.batchMsg)
+    GhcMonad m
+    => FilePath -- The file we are loading it because of
+    -> Cradle
+    -> m ()
+initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage Nothing
 
--- | Initialize the 'DynFlags' relating to the compilation of a single
--- file or GHC session according to the 'Cradle' and 'Options'
--- provided.
 initializeFlagsWithCradleWithMessage ::
-        (GhcMonad m)
-        => Maybe G.Messager
-        -> FilePath -- The file we are loading it because of
-        -> Cradle
-        -> m ()
+  GhcMonad m
+  => Maybe G.Messager
+  -> FilePath -- The file we are loading it because of
+  -> Cradle
+  -> m ()
 initializeFlagsWithCradleWithMessage msg fp cradle = do
-      compOpts <- getCompilerOptions fp cradle
-      initSessionWithMessage msg compOpts
-
-data CradleError = CradleError String deriving (Show)
-
-instance Exception CradleError where
-
-throwCradleError :: GhcMonad m => String -> m ()
-throwCradleError = liftIO . throwIO . CradleError
-
-----------------------------------------------------------------
-cacheDir :: String
-cacheDir = "haskell-ide-engine"
-
-clearInterfaceCache :: FilePath -> IO ()
-clearInterfaceCache fp = do
-  cd <- getCacheDir fp
-  res <- doesPathExist cd
-  when res (removeDirectoryRecursive cd)
-
-getCacheDir :: FilePath -> IO FilePath
-getCacheDir fp = getXdgDirectory XdgCache (cacheDir ++ "/" ++ fp)
+    compOpts <- liftIO $ getCompilerOptions fp cradle
+    case compOpts of
+      Left err -> liftIO $ throwIO err
+      Right opts -> initSessionWithMessage msg opts
 
 initSessionWithMessage :: (GhcMonad m)
             => Maybe G.Messager
             -> CompilerOptions
             -> m ()
-initSessionWithMessage msg CompilerOptions {..} = do
-    df <- G.getSessionDynFlags
-    traceShowM (length ghcOptions)
-
-    let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init (map B.pack ghcOptions)
-    fp <- liftIO $ getCacheDir opts_hash
-    -- For now, clear the cache initially rather than persist it across
-    -- sessions
-    liftIO $ clearInterfaceCache opts_hash
-    (df', targets) <- addCmdOpts ghcOptions df
-    void $ G.setSessionDynFlags
-      (disableOptimisation
-      $ setIgnoreInterfacePragmas
-      $ resetPackageDb
---      $ ignorePackageEnv
-      $ writeInterfaceFiles (Just fp)
-      $ setVerbosity 0
-
-      $ setLinkerOptions df'
-      )
-    G.setLogAction (\_df _wr _s _ss _pp _m -> return ())
-#if __GLASGOW_HASKELL__ < 806
-        (\_df -> return ())
-#endif
+initSessionWithMessage msg compOpts = do
+    targets <- initSession compOpts
     G.setTargets targets
     -- Get the module graph using the function `getModuleGraph`
     mod_graph <- G.depanal [] True
     void $ G.load' LoadAllTargets msg mod_graph
 
 ----------------------------------------------------------------
-
--- we don't want to generate object code so we compile to bytecode
--- (HscInterpreted) which implies LinkInMemory
--- HscInterpreted
-setLinkerOptions :: DynFlags -> DynFlags
-setLinkerOptions df = df {
-    ghcLink   = LinkInMemory
-  , hscTarget = HscNothing
-  , ghcMode = CompManager
-  }
-
-resetPackageDb :: DynFlags -> DynFlags
-resetPackageDb df = df { pkgDatabase = Nothing }
-
---ignorePackageEnv :: DynFlags -> DynFlags
---ignorePackageEnv df = df { packageEnv = Just "-" }
-
-setIgnoreInterfacePragmas :: DynFlags -> DynFlags
-setIgnoreInterfacePragmas df = gopt_set df Opt_IgnoreInterfacePragmas
-
-setVerbosity :: Int -> DynFlags -> DynFlags
-setVerbosity n df = df { verbosity = n }
-
-writeInterfaceFiles :: Maybe FilePath -> DynFlags -> DynFlags
-writeInterfaceFiles Nothing df = df
-writeInterfaceFiles (Just hi_dir) df = setHiDir hi_dir (gopt_set df Opt_WriteInterface)
-
-setHiDir :: FilePath -> DynFlags -> DynFlags
-setHiDir f d = d { hiDir      = Just f}
-
-
-addCmdOpts :: (GhcMonad m)
-           => [String] -> DynFlags -> m (DynFlags, [G.Target])
-addCmdOpts cmdOpts df1 = do
-  (df2, leftovers, warns) <- G.parseDynamicFlags df1 (map G.noLoc cmdOpts)
-  traceShowM (map G.unLoc leftovers, length warns)
-
-  let
-     -- To simplify the handling of filepaths, we normalise all filepaths right
-     -- away. Note the asymmetry of FilePath.normalise:
-     --    Linux:   p/q -> p/q; p\q -> p\q
-     --    Windows: p/q -> p\q; p\q -> p\q
-     -- #12674: Filenames starting with a hypen get normalised from ./-foo.hs
-     -- to -foo.hs. We have to re-prepend the current directory.
-    normalise_hyp fp
-        | strt_dot_sl && "-" `isPrefixOf` nfp = cur_dir ++ nfp
-        | otherwise                           = nfp
-        where
-#if defined(mingw32_HOST_OS)
-          strt_dot_sl = "./" `isPrefixOf` fp || ".\\" `isPrefixOf` fp
-#else
-          strt_dot_sl = "./" `isPrefixOf` fp
-#endif
-          cur_dir = '.' : [pathSeparator]
-          nfp = normalise fp
-    normal_fileish_paths = map (normalise_hyp . G.unLoc) leftovers
-  let
-   (srcs, objs) = partition_args normal_fileish_paths [] []
-   df3 = df2 { ldInputs = map (FileOption "") objs ++ ldInputs df2 }
-  ts <- mapM (uncurry G.guessTarget) srcs
-  return (df3, ts)
-    -- TODO: Need to handle these as well
-    -- Ideally it requires refactoring to work in GHCi monad rather than
-    -- Ghc monad and then can just use newDynFlags.
-    {-
-    liftIO $ G.handleFlagWarnings idflags1 warns
-    when (not $ null leftovers)
-        (throwGhcException . CmdLineError
-         $ "Some flags have not been recognized: "
-         ++ (concat . intersperse ", " $ map unLoc leftovers))
-    when (interactive_only && packageFlagsChanged idflags1 idflags0) $ do
-       liftIO $ hPutStrLn stderr "cannot set package flags with :seti; use :set"
-    -}
-
-----------------------------------------------------------------
-
-
-----------------------------------------------------------------
-
--- | Return the 'DynFlags' currently in use in the GHC session.
-getDynamicFlags :: IO DynFlags
-getDynamicFlags = do
-    mlibdir <- getSystemLibDir
-    G.runGhc mlibdir G.getSessionDynFlags
 
 withDynFlags ::
   (GhcMonad m)
@@ -264,54 +119,12 @@ withCmdFlags flags body = G.gbracket setup teardown (\_ -> body)
         return dflag
     teardown = void . G.setSessionDynFlags
 
--- partition_args, along with some of the other code in this file,
--- was copied from ghc/Main.hs
--- -----------------------------------------------------------------------------
--- Splitting arguments into source files and object files.  This is where we
--- interpret the -x <suffix> option, and attach a (Maybe Phase) to each source
--- file indicating the phase specified by the -x option in force, if any.
-partition_args :: [String] -> [(String, Maybe G.Phase)] -> [String]
-               -> ([(String, Maybe G.Phase)], [String])
-partition_args [] srcs objs = (reverse srcs, reverse objs)
-partition_args ("-x":suff:args) srcs objs
-  | "none" <- suff      = partition_args args srcs objs
-  | G.StopLn <- phase     = partition_args args srcs (slurp ++ objs)
-  | otherwise           = partition_args rest (these_srcs ++ srcs) objs
-        where phase = G.startPhase suff
-              (slurp,rest) = break (== "-x") args
-              these_srcs = zip slurp (repeat (Just phase))
-partition_args (arg:args) srcs objs
-  | looks_like_an_input arg = partition_args args ((arg,Nothing):srcs) objs
-  | otherwise               = partition_args args srcs (arg:objs)
-
-    {-
-      We split out the object files (.o, .dll) and add them
-      to ldInputs for use by the linker.
-      The following things should be considered compilation manager inputs:
-       - haskell source files (strings ending in .hs, .lhs or other
-         haskellish extension),
-       - module names (not forgetting hierarchical module names),
-       - things beginning with '-' are flags that were not recognised by
-         the flag parser, and we want them to generate errors later in
-         checkOptions, so we class them as source files (#5921)
-       - and finally we consider everything without an extension to be
-         a comp manager input, as shorthand for a .hs or .lhs filename.
-      Everything else is considered to be a linker object, and passed
-      straight through to the linker.
-    -}
-looks_like_an_input :: String -> Bool
-looks_like_an_input m =  G.isSourceFilename m
-                      || G.looksLikeModuleName m
-                      || "-" `isPrefixOf` m
-                      || not (hasExtension m)
-
-
 ----------------------------------------------------------------
 
 setDeferTypeErrors :: DynFlags -> DynFlags
 setDeferTypeErrors
-  = foldDFlags (flip wopt_set) [Opt_WarnTypedHoles, Opt_WarnDeferredTypeErrors, Opt_WarnDeferredOutOfScopeVariables]
-  . foldDFlags setGeneralFlag' [Opt_DeferTypedHoles, Opt_DeferTypeErrors, Opt_DeferOutOfScopeVariables]
+    = foldDFlags (flip wopt_set) [Opt_WarnTypedHoles, Opt_WarnDeferredTypeErrors, Opt_WarnDeferredOutOfScopeVariables]
+    . foldDFlags setGeneralFlag' [Opt_DeferTypedHoles, Opt_DeferTypeErrors, Opt_DeferOutOfScopeVariables]
 
 foldDFlags :: (a -> DynFlags -> DynFlags) -> [a] -> DynFlags -> DynFlags
 foldDFlags f xs x = foldr f x xs
@@ -324,8 +137,6 @@ setNoWarningFlags df = df { warningFlags = Gap.emptyWarnFlags}
 setAllWarningFlags :: DynFlags -> DynFlags
 setAllWarningFlags df = df { warningFlags = allWarningFlags }
 
-disableOptimisation :: DynFlags -> DynFlags
-disableOptimisation df = updOptLevel 0 df
 
 {-# NOINLINE allWarningFlags #-}
 allWarningFlags :: Gap.WarnFlags

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -100,13 +100,7 @@ initializeFlagsWithCradleWithMessage ::
         -> Cradle
         -> m ()
 initializeFlagsWithCradleWithMessage msg fp cradle = do
-      (ex, err, ghcOpts) <- liftIO $ getOptions (cradleOptsProg cradle) fp
-      G.pprTrace "res" (G.text (show (ex, err, ghcOpts, fp))) (return ())
-      case ex of
-        ExitFailure _ -> throwCradleError err
-        _ -> return ()
-      let compOpts = CompilerOptions ghcOpts
-      liftIO $ hPrint stderr ghcOpts
+      compOpts <- getCompilerOptions fp cradle
       initSessionWithMessage msg compOpts
 
 data CradleError = CradleError String deriving (Show)

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables, RecordWildCards, CPP #-}
 
-module HIE.Bios.GHCApi (
+module HIE.Bios.Ghc.Api (
     withGHC
   , withGHC'
   , withGhcT
@@ -37,7 +37,7 @@ import System.Process (readProcess)
 import System.Directory
 import System.FilePath
 
-import qualified HIE.Bios.Gap as Gap
+import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Types
 import Debug.Trace
 import qualified Crypto.Hash.SHA1 as H

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -1,4 +1,4 @@
-module HIE.Bios.Check (
+module HIE.Bios.Ghc.Check (
     checkSyntax
   , check
   , expandTemplate
@@ -8,10 +8,10 @@ module HIE.Bios.Check (
 import DynFlags (dopt_set, DumpFlag(Opt_D_dump_splices))
 import GHC (Ghc, DynFlags(..), GhcMonad)
 
-import HIE.Bios.GHCApi
-import HIE.Bios.Logger
+import HIE.Bios.Ghc.Api
+import HIE.Bios.Ghc.Logger
 import HIE.Bios.Types
-import HIE.Bios.Load
+import HIE.Bios.Ghc.Load
 import Outputable
 
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Ghc/Doc.hs
+++ b/src/HIE/Bios/Ghc/Doc.hs
@@ -1,10 +1,10 @@
-module HIE.Bios.Doc where
+module HIE.Bios.Ghc.Doc where
 
 import GHC (DynFlags, getPrintUnqual, pprCols, GhcMonad)
 import Outputable (PprStyle, SDoc, withPprStyleDoc, neverQualify)
 import Pretty (Mode(..), Doc, Style(..), renderStyle, style)
 
-import HIE.Bios.Gap (makeUserStyle)
+import HIE.Bios.Ghc.Gap (makeUserStyle)
 
 showPage :: DynFlags -> PprStyle -> SDoc -> String
 showPage dflag stl = showDocWith dflag PageMode . withPprStyleDoc dflag stl

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TypeSynonymInstances, FlexibleInstances, CPP #-}
+{-# LANGUAGE FlexibleInstances, CPP #-}
 
-module HIE.Bios.Gap (
+module HIE.Bios.Ghc.Gap (
     WarnFlags
   , emptyWarnFlags
   , makeUserStyle

--- a/src/HIE/Bios/Ghc/Ghc.hs
+++ b/src/HIE/Bios/Ghc/Ghc.hs
@@ -1,7 +1,7 @@
 -- | The Happy Haskell Programming library.
 --   API for interactive processes
 
-module HIE.Bios.Ghc (
+module HIE.Bios.Ghc.Ghc (
   -- * Converting the Ghc monad to the IO monad
     withGHC
   , withGHC'
@@ -12,5 +12,4 @@ module HIE.Bios.Ghc (
   , getSystemLibDir
   ) where
 
-import HIE.Bios.Check
-import HIE.Bios.GHCApi
+import HIE.Bios.Ghc.Api

--- a/src/HIE/Bios/Ghc/Internal.hs
+++ b/src/HIE/Bios/Ghc/Internal.hs
@@ -1,6 +1,6 @@
 -- | The Happy Haskell Programming library in low level.
 
-module HIE.Bios.Internal (
+module HIE.Bios.Ghc.Internal (
   -- * Types
   CompilerOptions(..)
   -- * IO
@@ -13,6 +13,6 @@ module HIE.Bios.Internal (
   , setAllWaringFlags
   ) where
 
-import HIE.Bios.GHCApi
-import HIE.Bios.Logger
+import HIE.Bios.Ghc.Api
+import HIE.Bios.Ghc.Logger
 import HIE.Bios.Types

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
-module HIE.Bios.Load ( loadFileWithMessage, loadFile, setTargetFiles, setTargetFilesWithMessage) where
+module HIE.Bios.Ghc.Load ( loadFileWithMessage, loadFile, setTargetFiles, setTargetFilesWithMessage) where
 
 import CoreMonad (liftIO)
 import GHC

--- a/src/HIE/Bios/Ghc/Logger.hs
+++ b/src/HIE/Bios/Ghc/Logger.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 
-module HIE.Bios.Logger (
+module HIE.Bios.Ghc.Logger (
     withLogger
   , checkErrorPrefix
   , getSrcSpan
@@ -22,8 +22,8 @@ import Data.List (isPrefixOf)
 import Data.Maybe (fromMaybe)
 import System.FilePath (normalise)
 
-import HIE.Bios.Doc (showPage, getStyle)
-import HIE.Bios.GHCApi (withDynFlags, withCmdFlags)
+import HIE.Bios.Ghc.Doc (showPage, getStyle)
+import HIE.Bios.Ghc.Api (withDynFlags, withCmdFlags)
 import HIE.Bios.Types (Options(..), convert)
 
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Ghc/Things.hs
+++ b/src/HIE/Bios/Ghc/Things.hs
@@ -1,4 +1,4 @@
-module HIE.Bios.Things (
+module HIE.Bios.Ghc.Things (
     GapThing(..)
   , fromTyThing
   , infoThing
@@ -18,7 +18,7 @@ import Var (varType)
 import Data.List (intersperse)
 import Data.Maybe (catMaybes)
 
-import HIE.Bios.Gap (getTyThing, fixInfo)
+import HIE.Bios.Ghc.Gap (getTyThing, fixInfo)
 
 -- from ghc/InteractiveUI.hs
 

--- a/src/HIE/Bios/Ghc/Types.hs
+++ b/src/HIE/Bios/Ghc/Types.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module HIE.Bios.Ghc.Types where
+
+
+import qualified Exception as GE
+import GHC (Ghc)
+
+import Control.Exception (IOException)
+import Control.Applicative (Alternative(..))
+
+
+instance Alternative Ghc where
+    x <|> y = x `GE.gcatch` (\(_ :: IOException) -> y)
+    empty = undefined

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -4,11 +4,6 @@
 
 module HIE.Bios.Types where
 
-import qualified Exception as GE
-import GHC (Ghc)
-
-import Control.Exception (IOException)
-import Control.Applicative (Alternative(..))
 import System.Exit
 import System.IO
 
@@ -172,7 +167,3 @@ instance Show CradleAction where
 data CompilerOptions = CompilerOptions {
     ghcOptions  :: [String]  -- ^ Command line options
   } deriving (Eq, Show)
-
-instance Alternative Ghc where
-    x <|> y = x `GE.gcatch` (\(_ :: IOException) -> y)
-    empty = undefined


### PR DESCRIPTION
Moves all files that are inherently specific to Ghc, making it trivial to extract another package out of it.
Exception is `Environment.hs` which initialises a Session.

Exposes new function `getCompilerOptions` to obtain compiler options.
cc @ndmitchell 