### PR TITLE
Split Cradle Logic into smaller components

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, LambdaCase #-}
 
 module Main where
 
@@ -55,7 +55,9 @@ main = flip E.catches handlers $ do
     args <- getArgs
     cradle <- getCurrentDirectory >>= \cwd ->
         -- find cradle does a takeDirectory on the argument, so make it into a file
-        findCradle $ cwd </> "File.hs"
+        findCradle (cwd </> "File.hs") >>= \case
+          Just yaml -> loadCradle yaml
+          Nothing -> loadImplicitCradle (cwd </> "File.hs")
     let cmdArg0 = args !. 0
         remainingArgs = tail args
         opt = defaultOptions

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -1,14 +1,16 @@
 -- | The HIE Bios
 
 module HIE.Bios (
-  -- * Initialise a session
+  -- * Find and load a Cradle
     Cradle(..)
   , findCradle
+  , loadCradle
+  , loadImplicitCradle
   , defaultCradle
   -- * Compiler Options
   , CompilerOptions(..)
   , getCompilerOptions
-  -- * Init session
+  -- * Initialise session
   , initSession
   ) where
 


### PR DESCRIPTION
API Changes: 

```haskell
-- | Given root/foo/bar.hs, return root/hie.yaml, or wherever the yaml file was found
findCradle :: FilePath -> IO (Maybe FilePath)

-- | Given root/hie.yaml load the Cradle
loadCradle :: FilePath -> IO Cradle

-- | Given root/foo/bar.hs, load an implicit cradle
loadImplicitCradle :: FilePath -> IO Cradle
```

Currently assumes, #26 will be merged, but can be rebased if necessary.
closes #9 afaik.
cc @ndmitchell 