### PR TITLE
Add support for GHC 8.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.6.4], sources: [hvr-ghc]}}
     - compiler: "ghc-8.4.4"
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.4.4], sources: [hvr-ghc]}}
+    - compiler: "ghc-8.2.2"
+      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.2.2], sources: [hvr-ghc]}}
 
 before_install:
   - HC=/opt/ghc/bin/${CC}

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -16,7 +16,7 @@ Extra-Source-Files:     ChangeLog
                         wrappers/cabal
                         wrappers/cabal.hs
 
-tested-with: GHC==8.6.4, GHC==8.4.4
+tested-with: GHC==8.6.4, GHC==8.4.4, GHC==8.2.2
 
 Library
   Default-Language:     Haskell2010
@@ -41,16 +41,16 @@ Library
                         base16-bytestring    >= 0.1.1 && < 0.2,
                         bytestring           >= 0.10.8 && < 0.11,
                         deepseq              >= 1.4.3 && < 1.5,
-                        containers           >= 0.5.11 && < 0.7,
+                        containers           >= 0.5.10 && < 0.7,
                         cryptohash-sha1      >= 0.11.100 && < 0.12,
-                        directory            >= 1.3.1 && < 1.4,
-                        filepath             >= 1.4.2 && < 1.5,
+                        directory            >= 1.3.0 && < 1.4,
+                        filepath             >= 1.4.1 && < 1.5,
                         time                 >= 1.8.0 && < 1.10,
                         extra                >= 1.6.18 && < 1.7,
                         process              >= 1.6.1 && < 1.7,
                         file-embed           >= 0.0.11 && < 0.1,
-                        ghc                  >= 8.4.1 && < 8.9,
-                        transformers         >= 0.5.5 && < 0.6,
+                        ghc                  >= 8.2.2 && < 8.9,
+                        transformers         >= 0.5.2 && < 0.6,
                         temporary            >= 1.2 && < 1.4,
                         text                 >= 1.2.3 && < 1.3,
                         unix-compat          >= 0.5.2 && < 0.6,

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -198,7 +198,7 @@ fixImportDirs :: FilePath -> String -> String
 fixImportDirs base_dir arg =
   if "-i" `isPrefixOf` arg
     then let dir = drop 2 arg
-         in if isRelative dir then ("-i" <> base_dir <> "/" <> dir)
+         in if isRelative dir then ("-i" ++ base_dir ++ "/" ++ dir)
                               else arg
     else arg
 

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -13,10 +13,12 @@ module HIE.Bios.Ghc.Gap (
   , LPattern
   , inTypes
   , outType
+  , mapMG
+  , mgModSummaries
   ) where
 
 import DynFlags (DynFlags)
-import GHC(LHsBind, LHsExpr, LPat, Type)
+import GHC(LHsBind, LHsExpr, LPat, Type, ModSummary, ModuleGraph)
 import HsExpr (MatchGroup)
 import Outputable (PrintUnqualified, PprStyle, Depth(AllTheWay), mkUserStyle)
 
@@ -31,7 +33,7 @@ import GHC.PackageDb (ExposedModule(..))
 #if __GLASGOW_HASKELL__ >= 804
 import DynFlags (WarningFlag)
 import qualified EnumSet as E (EnumSet, empty)
-import GHC (mgModSummaries, ModSummary, ModuleGraph)
+import GHC (mgModSummaries, mapMG)
 #else
 import qualified Data.IntSet as I (IntSet, empty)
 #endif
@@ -126,4 +128,16 @@ inTypes :: MatchGroup Id LExpression -> [Type]
 inTypes = mg_arg_tys
 outType :: MatchGroup Id LExpression -> Type
 outType = mg_res_ty
+#endif
+
+#if __GLASGOW_HASKELL__ >= 804
+#else
+mapMG :: (ModSummary -> ModSummary) -> ModuleGraph -> ModuleGraph
+mapMG = map
+#endif
+
+#if __GLASGOW_HASKELL__ >= 804
+#else
+mgModSummaries :: ModuleGraph -> [ModSummary]
+mgModSummaries = id
 #endif

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -23,6 +23,7 @@ import Debug.Trace
 import Data.List
 
 import Data.Time.Clock
+import qualified HIE.Bios.Ghc.Gap as Gap
 
 #if __GLASGOW_HASKELL__ < 806
 pprTraceM :: Monad m => String -> SDoc -> m ()
@@ -80,7 +81,7 @@ updateTime ts graph = liftIO $ do
   let go ms
         | any (msTargetIs ms) ts = ms {ms_hs_date = cur_time}
         | otherwise = ms
-  pure $ mapMG go graph
+  pure $ Gap.mapMG go graph
 
 -- | Set the files as targets and load them.
 setTargetFilesWithMessage :: (GhcMonad m)  => Maybe G.Messager -> [(FilePath, FilePath)] -> m ()
@@ -89,8 +90,8 @@ setTargetFilesWithMessage msg files = do
     pprTrace "setTargets" (vcat (map (\(a,b) -> parens $ text a <+> text "," <+> text b) files) $$ ppr targets) (return ())
     G.setTargets (map (\t -> t { G.targetAllowObjCode = False }) targets)
     mod_graph <- updateTime targets =<< depanal [] False
-    pprTrace "modGraph" (ppr $ mgModSummaries mod_graph) (return ())
-    pprTrace "modGraph" (ppr $ map ms_location $ mgModSummaries mod_graph) (return ())
+    pprTrace "modGraph" (ppr $ Gap.mgModSummaries mod_graph) (return ())
+    pprTrace "modGraph" (ppr $ map ms_location $ Gap.mgModSummaries mod_graph) (return ())
     dflags1 <- getSessionDynFlags
     pprTrace "hidir" (ppr $ hiDir dflags1) (return ())
     void $ G.load' LoadAllTargets msg mod_graph


### PR DESCRIPTION
Since hie supports ghc 8.2..2 - 8.6.5, hie-bios also ought to support ghc 8.2.2
Lowers the bounds of packages and fix small ghc lib version differences.

This pr includes a change to .travis.yaml to include ghc 8.2.2.
To show it compiles: https://travis-ci.org/fendor/hie-bios/builds/585529732