### PR TITLE
Add searchable cradle dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ by the `cabal` cradle.
 cradle:
   cabal:
     component: "lib:hie-bios"
-  dependencies:
-    - package.yaml
-    - shell.nix
-    - default.nix
+
+dependencies:
+  - package.yaml
+  - shell.nix
+  - default.nix
 ```
 
 For the `Bios` cradle type, there is an optional field to specify a program
@@ -116,8 +117,8 @@ cradle:
     arguments: ["list","of","ghc","arguments"]
   default:
 
-  dependencies:
-    - someDep
+dependencies:
+  - someDep
 ```
 
 ## Implicit Configuration

--- a/README.md
+++ b/README.md
@@ -53,17 +53,71 @@ relative to the current working directory if it is not an absolute path.
 cradle: {bios: {program: ".hie-bios"}}
 ```
 
+### Cradle Dependencies
+
+Sometimes it is necessary to reload a cradle, for example when a package
+dependency is added to the project. Each type of cradle defines a list of
+files that might cause an existing cradle to no longer provide accurate
+diagnostics if changed. These are expected to be relative to the root of
+the cradle.
+
+This makes it possible to watch for changes to these files and reload the
+cradle appropiately.
+However, if there are files that are not covered by
+the cradle dependency resolution, you can add these files explicitly to
+`hie.yaml`.
+These files are not required to actually exist, since it can be useful
+to know when these files are created, e.g. if there was no `cabal.project`
+in the project before and now there is, it might change how a file in the
+project is compiled.
+
+As an example how you would add cradle dependencies that may not be covered
+by the `cabal` cradle.
+
+```yaml
+cradle:
+  cabal:
+    component: "lib:hie-bios"
+  dependencies:
+    - package.yaml
+    - shell.nix
+    - default.nix
+```
+
+For the `Bios` cradle type, there is an optional field to specify a program
+to obtain cradle dependencies from:
+
+```yaml
+cradle:
+  bios:
+    program: ./flags.sg
+    dependency-program: ./dependency.sh
+```
+
+The program `./dependency.sh` is executed with no paramaters and it is
+expected to output on stdout on each line exactly one filepath relative
+to the root of the cradle, not relative to the location of the program.
+
+## Configuration specification
+
 The complete configuration is a subset of
 
 ```yaml
 cradle:
-  cabal: {component: "optional component name"}
+  cabal:
+    component: "optional component name"
   stack:
   bazel:
   obelisk:
-  bios: {program: "program to run"}
-  direct: {arguments: ["list","of","ghc","arguments"]}
+  bios:
+    program: "program to run"
+    dependency-program: "optional program to run"
+  direct:
+    arguments: ["list","of","ghc","arguments"]
   default:
+
+  dependencies:
+    - someDep
 ```
 
 ## Implicit Configuration
@@ -80,8 +134,8 @@ The targets are searched for in following order.
 2. An `obelisk` project
 3. A `rules_haskell` project
 4. A `stack` project
-4. A `cabal` project
-5. The default cradle which has no specific options.
+5. A `cabal` project
+6. The default cradle which has no specific options.
 
 ### `cabal-install`
 

--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -75,7 +75,7 @@ parseCabal (Object x)
     = return $ Cabal Nothing
 
     | otherwise
-    = fail "Not a valid Bios Configuration type, following keys are allowed: component"
+    = fail "Not a valid Cabal Configuration type, following keys are allowed: component"
 parseCabal _ = fail "Cabal Configuration is expected to be an object."
 
 parseBios :: Value -> Parser CradleType

--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -99,13 +99,17 @@ data Config = Config { cradle :: CradleConfig }
 
 instance FromJSON Config where
     parseJSON (Object val) = do
-        crd     <- val .: "cradle"
-        crdDeps <- val .:? "dependencies" .!= []
-        return Config
-            { cradle = CradleConfig { cradleType         = crd
-                                    , cradleDependencies = crdDeps
-                                    }
-            }
+            crd     <- val .: "cradle"
+            crdDeps <- case Map.size val of
+                1 -> return []
+                2 -> val .: "dependencies"
+                _ -> fail "Unknown key, following keys are allowed: cradle, dependencies"
+
+            return Config
+                { cradle = CradleConfig { cradleType         = crd
+                                        , cradleDependencies = crdDeps
+                                        }
+                }
 
     parseJSON _ = fail "Expected a cradle: key containing the preferences, possible values: cradle, dependencies"
 

--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -3,36 +3,99 @@
 module HIE.Bios.Config(
     readConfig,
     Config(..),
-    CradleConfig(..)
+    CradleConfig(..),
+    CradleType(..)
     ) where
 
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.HashMap.Strict as Map
-import Data.Yaml
+import           Data.Yaml
 
+data CradleConfig =
+    CradleConfig
+        { cradleDependencies :: [FilePath]
+        -- ^ Dependencies of a cradle.
+        -- Dependencies are expected to be relative to the root directory.
+        -- The given files are not required to exist.
+        , cradleType :: CradleType
+        -- ^ Type of the cradle to use. Actions to obtain
+        -- compiler flags from are dependant on this field.
+        }
+        deriving (Show)
 
-data CradleConfig = Cabal { component :: Maybe String }
-                  | Stack
-                  | Bazel
-                  | Obelisk
-                  | Bios { prog :: FilePath }
-                  | Direct { arguments :: [String] }
-                  | Default
-                  deriving (Show)
+data CradleType
+    = Cabal { component :: Maybe String }
+    | Stack
+    | Bazel
+    | Obelisk
+    | Bios
+        { prog :: FilePath
+        -- ^ Path to program that retrieves options to compile a file
+        , depsProg :: Maybe FilePath
+        -- ^ Optional Path to program to obtain cradle dependencies.
+        -- Each cradle dependency is to be expected to be on a separate line
+        -- and relative to the root dir of the cradle, not relative
+        -- to the location of this program.
+        }
+    | Direct { arguments :: [String] }
+    | Default
+    deriving (Show)
 
 instance FromJSON CradleConfig where
-    parseJSON (Object (Map.toList -> [(key, val)]))
-        | key == "cabal" = case val of
-            Object x | Just (String v) <- Map.lookup "component" x -> return $ Cabal $ Just $ T.unpack v
-            _ -> return $ Cabal Nothing
-        | key == "stack" = return Stack
-        | key == "bazel" = return Bazel
-        | key == "obelisk" = return Obelisk
-        | key == "bios", Object x <- val, Just (String v) <- Map.lookup "program" x = return $ Bios $ T.unpack v
-        | key == "direct", Object x <- val, Just (Array v) <- Map.lookup "arguments" x = return $ Direct [T.unpack s | String s <- V.toList v]
-        | key == "default" = return Default
+    parseJSON (Object o) = do
+        deps <- o .:? "dependencies" .!= []
+        crdType <- parseCradleType o
+        return $ CradleConfig deps crdType
+
+    parseJSON _ = error "me"
+
+instance FromJSON CradleType where
+    parseJSON (Object o) = parseCradleType o
     parseJSON _ = fail "Not a known configuration"
+
+parseCradleType :: Object -> Parser CradleType
+parseCradleType o
+    | Just val <- Map.lookup "cabal" o = parseCabal val
+    | Just _val <- Map.lookup "stack" o = return Stack
+    | Just _val <- Map.lookup "bazel" o = return Bazel
+    | Just _val <- Map.lookup "obelisk" o = return Obelisk
+    | Just val <- Map.lookup "bios" o = parseBios val
+    | Just val <- Map.lookup "direct" o = parseDirect val
+    | Just _val <- Map.lookup "default" o = return Default
+parseCradleType o = fail $ "Unknown cradle type: " ++ show o
+
+parseCabal :: Value -> Parser CradleType
+parseCabal cabalValue
+    | Object x <- cabalValue
+    , Just (String cabalComponent) <- Map.lookup "component" x
+    = return $ Cabal $ Just $ T.unpack cabalComponent
+
+    | Object _ <- cabalValue
+    = return $ Cabal Nothing
+
+    | otherwise
+    = fail $ "Could not parse Cabal component for value: " ++ show cabalValue
+
+parseBios :: Value -> Parser CradleType
+parseBios biosValue
+    | Object x <- biosValue
+    , Just (String biosProgram) <- Map.lookup "program" x
+    = case  Map.lookup "dependency-program" x of
+        Just (String deps) -> return $ Bios (T.unpack biosProgram) (Just (T.unpack deps))
+        _ -> return $ Bios (T.unpack biosProgram) Nothing
+
+    | otherwise
+    = fail "Not a valid Bios Configuration type"
+
+parseDirect :: Value -> Parser CradleType
+parseDirect directValue
+    | Object x <- directValue
+    , Just (Array v) <- Map.lookup "arguments" x
+    = return $ Direct [T.unpack s | String s <- V.toList v]
+
+    | otherwise
+    = fail "Not a correct Direct Configuration type"
 
 data Config = Config { cradle :: CradleConfig }
     deriving (Show)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -136,7 +136,7 @@ biosCradle wdir biosProg biosDepsProg deps =
     { cradleRootDir    = wdir
     , cradleOptsProg   = CradleAction
         { actionName = "bios"
-        , getDependencies = fmap (deps \\) (biosDepsAction biosDepsProg)
+        , getDependencies = fmap (deps `union`) (biosDepsAction biosDepsProg)
         -- Execute the bios action and add dependencies of the cradle.
         -- Removes all duplicates.
         , getOptions = biosAction wdir biosProg
@@ -172,7 +172,7 @@ cabalCradle wdir mc deps =
     { cradleRootDir    = wdir
     , cradleOptsProg   = CradleAction
         { actionName = "cabal"
-        , getDependencies = fmap (deps \\) (cabalCradleDependencies wdir)
+        , getDependencies = fmap (deps `union`) (cabalCradleDependencies wdir)
         , getOptions = cabalAction wdir mc
         }
     }
@@ -260,7 +260,7 @@ stackCradle wdir deps =
     { cradleRootDir    = wdir
     , cradleOptsProg   = CradleAction
         { actionName = "stack"
-        , getDependencies = fmap (deps \\) (stackCradleDependencies wdir)
+        , getDependencies = fmap (deps `union`) (stackCradleDependencies wdir)
         , getOptions = stackAction wdir
         }
     }
@@ -318,7 +318,7 @@ rulesHaskellCradle wdir deps =
     { cradleRootDir  = wdir
     , cradleOptsProg   = CradleAction
         { actionName = "bazel"
-        , getDependencies = fmap (deps \\) (rulesHaskellCradleDependencies wdir)
+        , getDependencies = fmap (deps `union`) (rulesHaskellCradleDependencies wdir)
         , getOptions = rulesHaskellAction wdir
         }
     }
@@ -364,7 +364,7 @@ obeliskCradle wdir deps =
     { cradleRootDir  = wdir
     , cradleOptsProg = CradleAction
         { actionName = "obelisk"
-        , getDependencies = fmap (deps \\) (obeliskCradleDependencies wdir)
+        , getDependencies = fmap (deps `union`) (obeliskCradleDependencies wdir)
         , getOptions = obeliskAction wdir
         }
     }

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -165,7 +165,8 @@ data CradleAction = CradleAction {
                       -- to which this CradleAction belongs to.
                       -- Files returned by this action might not actually exist.
                       -- This is useful, because, sometimes, adding specific files
-                      -- changes the options that a Cradle may return.
+                      -- changes the options that a Cradle may return, thus, needs reload
+                      -- as soon as these files are created.
                       , getOptions :: FilePath -> IO (ExitCode, String, [String])
                       -- ^ Options to compile the given file with.
                       -- The result consists of the return code of the operation

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -156,11 +156,25 @@ data Cradle = Cradle {
 
 data CradleAction = CradleAction {
                       actionName :: String
-                      , getOptions ::  (FilePath -> IO (ExitCode, String, [String]))
+                      -- ^ Name of the action
+                      , getDependencies :: IO [FilePath]
+                      -- ^ Dependencies of a cradle that might change the cradle.
+                      -- Contains both files specified in hie.yaml as well as
+                      -- specified by the build-tool if there is any.
+                      -- FilePaths are expected to be relative to the `cradleRootDir`
+                      -- to which this CradleAction belongs to.
+                      -- Files returned by this action might not actually exist.
+                      -- This is useful, because, sometimes, adding specific files
+                      -- changes the options that a Cradle may return.
+                      , getOptions :: FilePath -> IO (ExitCode, String, [String])
+                      -- ^ Options to compile the given file with.
+                      -- The result consists of the return code of the operation
+                      -- that has been run, the stdout of the process, and a list of
+                      -- options that are needed to compile the given file.
                       }
 
 instance Show CradleAction where
-  show (CradleAction name _) = "CradleAction: " ++ name
+  show CradleAction { actionName = name } = "CradleAction: " ++ name
 ----------------------------------------------------------------
 
 -- | Option information for GHC


### PR DESCRIPTION
Extends hie.yaml file format with the "dependencies" object.
Extends Bios cradle type with an optional FilePath to
obtain cradle dependencies from.

Set for each cradle type the cradle dependencies.

Reorganise parsing of "hie.yaml".

* [x] For each cradle type, implement a function that returns dependencies common to the respective cradle type.
* [x] Test the parsing of `hie.yaml` a bit more, smoke testing succeeded

Note: parsing of hie.yaml is less strict now, if there is a field such as "dependecies" (note missing 'n'), it will parse, assuming the correct field "dependencies" is not defined. 

Closes #35
Makes #39 obsolete