### PR TITLE
Delimit GHC arguments

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -155,9 +155,20 @@ processCabalWrapperArgs :: String -> Maybe [String]
 processCabalWrapperArgs args =
     case lines args of
         [dir, ghc_args] ->
-            let final_args = removeInteractive $ map (fixImportDirs dir) (words ghc_args)
+            let final_args =
+                    removeInteractive
+                    $ map (fixImportDirs dir)
+                    $ limited ghc_args
             in Just final_args
         _ -> Nothing
+  where
+    limited :: String -> [String]
+    limited = unfoldr $ \argstr ->
+        if null argstr
+        then Nothing
+        else
+            let (arg, argstr') = break (== '\NUL') argstr
+            in Just (arg, drop 1 argstr')
 
 -- generate a fake GHC that can be passed to cabal
 -- when run with --interactive, it will print out its

--- a/src/HIE/Bios/Debug.hs
+++ b/src/HIE/Bios/Debug.hs
@@ -2,6 +2,7 @@ module HIE.Bios.Debug (debugInfo, rootInfo) where
 
 import Control.Monad.IO.Class (liftIO)
 
+import qualified Data.Char as Char
 import Data.Maybe (fromMaybe)
 
 import HIE.Bios.Ghc.Api
@@ -18,11 +19,14 @@ debugInfo opt cradle = convert opt <$> do
     mglibdir <- liftIO getSystemLibDir
     return [
         "Root directory:      " ++ rootDir
-      , "GHC options:         " ++ unwords gopts
+      , "GHC options:         " ++ unwords (map quoteIfNeeded gopts)
       , "System libraries:    " ++ fromMaybe "" mglibdir
       ]
   where
     rootDir    = cradleRootDir cradle
+    quoteIfNeeded option
+      | any Char.isSpace option = "\"" ++ option ++ "\""
+      | otherwise = option
 
 ----------------------------------------------------------------
 

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 if [ "$1" == "--interactive" ]; then
   pwd
-  echo "$@"
+  for arg in "$@"; do
+    echo -ne "$arg\x00"
+  done
+  echo -ne "\n"
 else
   ghc "$@"
 fi

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -17,4 +17,4 @@ main = do
       exitWith code
 
 delimited :: [String] -> String
-delimited = foldr (\a as -> a ++ '\NUL' : as) ""
+delimited = concatMap (++ "\NUL")

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -17,4 +17,4 @@ main = do
       exitWith code
 
 delimited :: [String] -> String
-delimited = (++) "-here " . foldr (\a as -> a ++ '\NUL' : as) ""
+delimited = foldr (\a as -> a ++ '\NUL' : as) ""

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -10,9 +10,11 @@ main = do
   case args of
     "--interactive":_ -> do
       getCurrentDirectory >>= putStrLn
-      -- note this probably breaks if paths have spaces in
-      putStrLn $ unwords args
+      putStrLn $ delimited args
     _ -> do
       ph <- spawnProcess "ghc" args
       code <- waitForProcess ph
       exitWith code
+
+delimited :: [String] -> String
+delimited = (++) "-here " . foldr (\a as -> a ++ '\NUL' : as) ""


### PR DESCRIPTION
The Cabal wrappers break if there are spaces in any argument to GHC. That can happen if paths have spaces, or with options like `-with-rtsopts=` which expect an argument containing spaces. This would delimit the list of arguments with NULL characters. NULL-terminated arguments allows GHC options to contain spaces without the overhead of Read/Show.