### PR TITLE
Ignore stack generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist/
 dist-newstyle/
+.stack-work/
+stack.yaml
+stack.yaml.lock


### PR DESCRIPTION
If someone wants to use Stack with hie-bios, they end up with a lot of garbage files in the repo. A git ignore keeps them from accidentally committing them.