### PR TITLE
Port stack cradle to windows reusing cabal one

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -229,6 +229,7 @@ getCabalWrapperTool = do
         return wrapper_fp
       else do
         writeSystemTempFile "bios-wrapper" cabalWrapper
+  -- TODO: This isn't portable for windows
   setFileMode wrapper_fp accessModes
   _check <- readFile wrapper_fp
   return wrapper_fp
@@ -281,15 +282,10 @@ stackCradleDependencies wdir = do
     cabalFiles <- findCabalFiles wdir
     return $ cabalFiles ++ ["package.yaml", "stack.yaml"]
 
--- Same wrapper works as with cabal
-stackWrapper :: String
-stackWrapper = $(embedStringFile "wrappers/cabal")
-
 stackAction :: FilePath -> FilePath -> IO (ExitCode, String, [String])
 stackAction work_dir fp = do
-  wrapper_fp <- writeSystemTempFile "wrapper" stackWrapper
-  -- TODO: This isn't portable for windows
-  setFileMode wrapper_fp accessModes
+  -- Same wrapper works as with cabal
+  wrapper_fp <- getCabalWrapperTool
   -- TODO: this is for debugging
   -- check <- readFile wrapper_fp
   -- traceM check

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -229,7 +229,7 @@ getCabalWrapperTool = do
         return wrapper_fp
       else do
         writeSystemTempFile "bios-wrapper" cabalWrapper
-  -- TODO: This isn't portable for windows
+
   setFileMode wrapper_fp accessModes
   _check <- readFile wrapper_fp
   return wrapper_fp
@@ -339,7 +339,6 @@ bazelCommand = $(embedStringFile "wrappers/bazel")
 rulesHaskellAction :: FilePath -> FilePath -> IO (ExitCode, String, [String])
 rulesHaskellAction work_dir fp = do
   wrapper_fp <- writeSystemTempFile "wrapper" bazelCommand
-  -- TODO: This isn't portable for windows
   setFileMode wrapper_fp accessModes
   let rel_path = makeRelative work_dir fp
   (ex, args, stde) <-


### PR DESCRIPTION
* Reusing `getCabalWrapperTool`
* Tested locally in windows 7
* Hopefully fixes #49, maybe #11 and partially #33 
* Output:
```console
D:\ws\haskell\stack-test>hie-bios check src\Lib.hs
cradle
  Cradle {cradleRootDir = "D:\\ws\\haskell\\stack-test", cradleOptsProg = Cradle
Action: stack}
[1 of 1] Compiling Main             ( C:\TEMP\wra9706.hs, C:\TEMP\wra9706.o )
Linking C:\TEMP\wra9727.exe ...
setTargets
  (src\Lib.hs , src\Lib.hs)
  [*src\Lib.hs]
modGraph
  [ModSummary {
      ms_hs_date = 2019-09-19 10:48:00.2052186 UTC
      ms_mod = Lib,
      ms_textual_imps = [(Nothing, Prelude), (Nothing, Data.Bifunctor)]
      ms_srcimps = []
   }]
modGraph
  [ModLocation {ml_hs_file = Just "src\\Lib.hs", ml_hi_file = "C:\\Users\\user\\A
ppData\\Local\\haskell-ide-engine\\3b7875f2994913e87022150ffb4d1f15c9fcf26f\\Lib
.hi", ml_obj_file = "D:\\ws\\haskell\\stack-test\\.stack-work\\odir\\Lib.o"}]
hidir
  Just [C, :, \, U, s, e, r, s, \, u, s, e, r, \, A, p, p, D, a, t, a,
        \, L, o, c, a, l, \, h, a, s, k, e, l, l, -, i, d, e, -, e, n, g,
        i, n, e, \, 3, b, 7, 8, 7, 5, f, 2, 9, 9, 4, 9, 1, 3, e, 8, 7, 0,
        2, 2, 1, 5, 0, f, f, b, 4, d, 1, f, 1, 5, c, 9, f, c, f, 2, 6, f]
src\Lib.hs:16:5:Warning: Defined but not used: data constructor ‘Const’
src\Lib.hs:17:5:Warning: Defined but not used: data constructor ‘X’
src\Lib.hs:18:5:Warning: Defined but not used: data constructor ‘Cos’
.......
src\Lib.hs:76:1:Warning: Defined but not used: ‘simplify’
```
