### PR TITLE
Implement the none cradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ cradle:
   direct:
     arguments: ["list","of","ghc","arguments"]
   default:
+  none:
 
 dependencies:
   - someDep

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -73,8 +73,12 @@ main = flip E.catches handlers $ do
         res <- forM remainingArgs $ \fp -> do
                 res <- getCompilerOptions fp cradle
                 case res of
-                    Left err -> return $ "Failed to show flags for \"" ++ fp ++ "\": " ++ show err
-                    Right opts -> return $ "CompilerOptions: " ++ show (ghcOptions opts)
+                    CradleFail (CradleError _ex err) ->
+                      return $ "Failed to show flags for \""
+                                                ++ fp
+                                                ++ "\": " ++ show err
+                    CradleSuccess opts -> return $ "CompilerOptions: " ++ show (ghcOptions opts)
+                    CradleNone -> return "No flags: this component should not be loaded"
         return (unlines res)
 
       "help"    -> return usage

--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -39,6 +39,7 @@ data CradleType
         }
     | Direct { arguments :: [String] }
     | Default
+    | None
     deriving (Show)
 
 instance FromJSON CradleType where
@@ -54,6 +55,7 @@ parseCradleType o
     | Just val <- Map.lookup "bios" o = parseBios val
     | Just val <- Map.lookup "direct" o = parseDirect val
     | Just _val <- Map.lookup "default" o = return Default
+    | Just _val <- Map.lookup "none" o = return None
 parseCradleType o = fail $ "Unknown cradle type: " ++ show o
 
 parseCabal :: Value -> Parser CradleType

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -63,6 +63,7 @@ getCradle (cc, wdir) = case cradleType cc of
     Bios bios deps  -> biosCradle wdir bios deps cradleDeps
     Direct xs -> directCradle wdir xs cradleDeps
     Default   -> defaultCradle wdir cradleDeps
+    None      -> noneCradle wdir
     where
       cradleDeps = cradleDependencies cc
 
@@ -109,6 +110,20 @@ defaultCradle cur_dir deps =
         { actionName = "default"
         , getDependencies = return deps
         , getOptions = const $ return (CradleSuccess (CompilerOptions []))
+        }
+    }
+
+---------------------------------------------------------------
+-- The none cradle tells us not to even attempt to load a certain directory
+
+noneCradle :: FilePath -> Cradle
+noneCradle cur_dir =
+  Cradle
+    { cradleRootDir = cur_dir
+    , cradleOptsProg = CradleAction
+        { actionName = "default"
+        , getDependencies = return []
+        , getOptions = const $ return CradleNone
         }
     }
 

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -1,11 +1,7 @@
 module HIE.Bios.Flags (getCompilerOptions, CradleError) where
 
-import Control.Monad.IO.Class
-import Control.Exception ( Exception )
+import HIE.Bios.Types
 
-import System.Exit (ExitCode(..))
-
-import HIE.Bios.Types (Cradle, CompilerOptions(..), getOptions, cradleOptsProg)
 
 -- | Initialize the 'DynFlags' relating to the compilation of a single
 -- file or GHC session according to the 'Cradle' and 'Options'
@@ -13,17 +9,9 @@ import HIE.Bios.Types (Cradle, CompilerOptions(..), getOptions, cradleOptsProg)
 getCompilerOptions ::
     FilePath -- The file we are loading it because of
     -> Cradle
-    -> IO (Either CradleError CompilerOptions)
+    -> IO (CradleLoadResult CompilerOptions)
 getCompilerOptions fp cradle = do
-  (ex, err, ghcOpts) <- liftIO $ getOptions (cradleOptsProg cradle) fp
-  case ex of
-    ExitFailure _ -> return $ Left (CradleError err)
-    _ -> do
-        let compOpts = CompilerOptions ghcOpts
-        return $ Right compOpts
+  getOptions (cradleOptsProg cradle) fp
 
-data CradleError = CradleError String deriving (Show)
-
-instance Exception CradleError where
 
 ----------------------------------------------------------------


### PR DESCRIPTION
The none cradle is meant to be used to tell your IDE to not even bother
trying to load a certain subdirectory.

For example, if your project contains lots of haskell files for testing
then you don't want to try to load these into your IDE when you open
them. If you're working on a project like GHC, many of them will fail to
load or even parse.
