### PR TITLE
Multi cradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,53 @@ cradle:
     arguments: ["list","of","ghc","arguments"]
   default:
   none:
+  multi: - path: ./
+           config: { cradle: ... }
 
 dependencies:
   - someDep
 ```
+
+## Multi-Cradle
+
+For a multi-component project you can use the multi-cradle to specify how each
+subdirectory of the project should be handled by the IDE.
+
+The multi-cradle is a list of relative paths and cradle configurations.
+The path is relative to the configuration file and specifies the scope of
+the cradle. For example, this configuration specificies that files in the
+`src` subdirectory should be handled with the `lib:hie-bios` component and
+files in the `test` directory using the `test` component.
+
+```
+cradle:
+  multi:
+    - path: "./src"
+      config: { cradle: {cabal: {component: "lib:hie-bios"}} }
+    - path: "./test"
+      config: { cradle: {cabal: {component: "test"}} }
+```
+
+If a file matches multiple prefixes, the most specific one is chosen.
+
+This cradle type is experimental and may not be supported correctly by
+some libraries which use `hie-bios`. It requires some additional care to
+correctly manage multiple components.
+
+Note: Remember you can use the multi-cradle to declare that certain directories
+shouldn't be loaded by an IDE, in conjunction with the `none` cradle.
+
+```
+cradle:
+  multi:
+    - path: "./src"
+      config: { cradle: {cabal: {component: "lib:hie-bios"}} }
+    - path: "./test"
+      config: { cradle: {cabal: {component: "test"}} }
+    - path: "./test/test-files"
+      config: { cradle: none }
+```
+
 
 ## Implicit Configuration
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -77,7 +77,9 @@ main = flip E.catches handlers $ do
                       return $ "Failed to show flags for \""
                                                 ++ fp
                                                 ++ "\": " ++ show err
-                    CradleSuccess opts -> return $ "CompilerOptions: " ++ show (ghcOptions opts)
+                    CradleSuccess opts ->
+                      return $ unlines ["Options: " ++ show (componentOptions opts)
+                                       ,"Dependencies: " ++ show (componentDependencies opts) ]
                     CradleNone -> return "No flags: this component should not be loaded"
         return (unlines res)
 

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -30,6 +30,7 @@ Library
                         HIE.Bios.Debug
                         HIE.Bios.Flags
                         HIE.Bios.Types
+                        HIE.Bios.Log
                         HIE.Bios.Ghc.Api
                         HIE.Bios.Ghc.Check
                         HIE.Bios.Ghc.Doc
@@ -58,7 +59,9 @@ Library
                         unix-compat          >= 0.5.1 && < 0.6,
                         unordered-containers >= 0.2.9 && < 0.3,
                         vector               >= 0.12.0 && < 0.13,
-                        yaml                 >= 0.8.32 && < 0.12
+                        yaml                 >= 0.8.32 && < 0.12,
+                        hslogger             >= 1.2 && < 1.4
+
 
 Executable hie-bios
   Default-Language:     Haskell2010

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -8,7 +8,7 @@ module HIE.Bios (
   , loadImplicitCradle
   , defaultCradle
   -- * Compiler Options
-  , CompilerOptions(..)
+  , ComponentOptions(..)
   , getCompilerOptions
   -- * Initialise session
   , initSession

--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
 module HIE.Bios.Config(
     readConfig,
     Config(..),
@@ -99,7 +100,7 @@ parseDirect _ = fail "Direct Configuration is expected to be an object."
 data Config = Config { cradle :: CradleConfig }
     deriving (Show, Eq)
 
-instance FromJSON Config where
+instance FromJSON CradleConfig where
     parseJSON (Object val) = do
             crd     <- val .: "cradle"
             crdDeps <- case Map.size val of
@@ -107,13 +108,15 @@ instance FromJSON Config where
                 2 -> val .: "dependencies"
                 _ -> fail "Unknown key, following keys are allowed: cradle, dependencies"
 
-            return Config
-                { cradle = CradleConfig { cradleType         = crd
-                                        , cradleDependencies = crdDeps
-                                        }
-                }
+            return $ CradleConfig { cradleType         = crd
+                                  , cradleDependencies = crdDeps
+                                  }
 
     parseJSON _ = fail "Expected a cradle: key containing the preferences, possible values: cradle, dependencies"
+
+
+instance FromJSON Config where
+    parseJSON o = Config <$> parseJSON o
 
 readConfig :: FilePath -> IO Config
 readConfig = decodeFileThrow

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -21,6 +21,7 @@ import Control.Applicative ((<|>))
 import Data.FileEmbed
 import System.IO.Temp
 import Data.List
+import Data.Ord (Down(..))
 
 import System.PosixCompat.Files
 
@@ -168,10 +169,8 @@ multiAction cur_dir cs cur_fp = selectCradle =<< canonicalizeCradles
     -- function we want to choose the most specific cradle possible.
     canonicalizeCradles :: IO [(FilePath, CradleConfig)]
     canonicalizeCradles =
-      sortBy (\(p1, _) (p2, _) ->
-        if p1 `isPrefixOf` p2
-          then GT
-          else LT) <$> mapM (\(p, c) -> (,c) <$> (canonicalizePath (cur_dir </> p))) cs
+      sortOn (Down . fst)
+        <$> mapM (\(p, c) -> (,c) <$> (canonicalizePath (cur_dir </> p))) cs
 
     selectCradle [] =
       return (CradleFail (CradleError ExitSuccess err_msg))

--- a/src/HIE/Bios/Debug.hs
+++ b/src/HIE/Bios/Debug.hs
@@ -15,10 +15,9 @@ debugInfo :: Options
           -> Cradle
           -> IO String
 debugInfo opt cradle = convert opt <$> do
-    res <- getOptions (cradleOptsProg cradle) (cradleRootDir cradle)
+    res <- runCradle (cradleOptsProg cradle) (cradleRootDir cradle)
     case res of
-      CradleSuccess (CompilerOptions gopts) -> do
-        deps  <- getDependencies (cradleOptsProg cradle)
+      CradleSuccess (ComponentOptions gopts deps) -> do
         mglibdir <- liftIO getSystemLibDir
         return [
             "Root directory:      " ++ rootDir

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -22,15 +22,15 @@ import Data.List
 import HIE.Bios.Types
 
 initSession :: (GhcMonad m)
-    => CompilerOptions
+    => ComponentOptions
     -> m [G.Target]
-initSession  CompilerOptions {..} = do
+initSession  ComponentOptions {..} = do
     df <- G.getSessionDynFlags
     -- traceShowM (length ghcOptions)
 
-    let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init (map B.pack ghcOptions)
+    let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init (map B.pack componentOptions)
     fp <- liftIO $ getCacheDir opts_hash
-    (df', targets) <- addCmdOpts ghcOptions df
+    (df', targets) <- addCmdOpts componentOptions df
     void $ G.setSessionDynFlags
         (disableOptimisation
         $ setIgnoreInterfacePragmas

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -26,7 +26,6 @@ initSession :: (GhcMonad m)
     -> m [G.Target]
 initSession  ComponentOptions {..} = do
     df <- G.getSessionDynFlags
-    -- traceShowM (length ghcOptions)
 
     let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init (map B.pack componentOptions)
     fp <- liftIO $ getCacheDir opts_hash
@@ -115,9 +114,6 @@ addCmdOpts :: (GhcMonad m)
            => [String] -> DynFlags -> m (DynFlags, [G.Target])
 addCmdOpts cmdOpts df1 = do
   (df2, leftovers, _warns) <- G.parseDynamicFlags df1 (map G.noLoc cmdOpts)
-  -- TODO: remove this trace
-  -- What about warnings?
-  -- traceShowM (map G.unLoc leftovers, length warns)
 
   let
      -- To simplify the handling of filepaths, we normalise all filepaths right

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -9,9 +9,9 @@ import HIE.Bios.Types
 getCompilerOptions ::
     FilePath -- The file we are loading it because of
     -> Cradle
-    -> IO (CradleLoadResult CompilerOptions)
+    -> IO (CradleLoadResult ComponentOptions)
 getCompilerOptions fp cradle = do
-  getOptions (cradleOptsProg cradle) fp
+  runCradle (cradleOptsProg cradle) fp
 
 
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -27,11 +27,11 @@ import qualified GhcMake as G
 
 import Control.Monad (void)
 import System.Exit (exitSuccess)
-import System.IO (hPutStr, hPrint, stderr)
 import System.IO.Unsafe (unsafePerformIO)
 
 import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Types
+import qualified HIE.Bios.Log as Log
 import HIE.Bios.Environment
 import HIE.Bios.Flags
 
@@ -47,8 +47,8 @@ withGHC file body = ghandle ignore $ withGHC' body
   where
     ignore :: SomeException -> IO a
     ignore e = do
-        hPutStr stderr $ file ++ ":0:0:Error:"
-        hPrint stderr e
+        Log.logm $ file ++ ":0:0:Error:"
+        Log.logm (show e)
         exitSuccess
 
 withGHC' :: Ghc a -> IO a

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -82,7 +82,7 @@ initializeFlagsWithCradleWithMessage msg fp cradle = do
 
 initSessionWithMessage :: (GhcMonad m)
             => Maybe G.Messager
-            -> CompilerOptions
+            -> ComponentOptions
             -> m ()
 initSessionWithMessage msg compOpts = do
     targets <- initSession compOpts

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -11,9 +11,9 @@ import Exception
 
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Logger
+import qualified HIE.Bios.Log as Log
 import HIE.Bios.Types
 import HIE.Bios.Ghc.Load
-import Outputable
 import Control.Monad.IO.Class
 
 ----------------------------------------------------------------
@@ -26,7 +26,7 @@ checkSyntax :: Options
             -> IO String
 checkSyntax _   _      []    = return ""
 checkSyntax opt cradle files = withGhcT $ do
-    pprTrace "cradle" (text $ show cradle) (return ())
+    Log.debugm $ "Cradle: " ++ show cradle
     res <- initializeFlagsWithCradle (head files) cradle
     case res of
       CradleSuccess ini -> do

--- a/src/HIE/Bios/Ghc/Load.hs
+++ b/src/HIE/Bios/Ghc/Load.hs
@@ -8,7 +8,6 @@ import qualified GHC as G
 import qualified GhcMake as G
 import qualified HscMain as G
 import HscTypes
-import Outputable
 import Control.Monad.IO.Class
 
 import Data.IORef
@@ -19,16 +18,11 @@ import TcRnTypes (FrontendResult(..))
 import Control.Monad (forM, void)
 import GhcMonad
 import HscMain
-import Debug.Trace
 import Data.List
 
 import Data.Time.Clock
 import qualified HIE.Bios.Ghc.Gap as Gap
-
-#if __GLASGOW_HASKELL__ < 806
-pprTraceM :: Monad m => String -> SDoc -> m ()
-pprTraceM x s = pprTrace x s (return ())
-#endif
+import qualified HIE.Bios.Log as Log
 
 -- | Obtaining type of a target expression. (GHCi's type:)
 loadFileWithMessage :: GhcMonad m
@@ -37,14 +31,14 @@ loadFileWithMessage :: GhcMonad m
          -> m (Maybe TypecheckedModule, [TypecheckedModule])
 loadFileWithMessage msg file = do
   dir <- liftIO $ getCurrentDirectory
-  pprTraceM "loadFile:2" (text dir)
+  Log.debugm $ "loadFile:2 " ++ dir
   df <- getSessionDynFlags
-  pprTraceM "loadFile:3" (ppr $ optLevel df)
-  (_, tcs) <- collectASTs $ do
+  Log.debugm $ "loadFile:3 " ++ show (optLevel df)
+  (_, tcs) <- collectASTs $
     (setTargetFilesWithMessage msg [file])
-  pprTraceM "loaded" (text (fst file) $$ text (snd file))
+  Log.debugm $ "loaded " ++ fst file ++ " - " ++ snd file
   let get_fp = ml_hs_file . ms_location . pm_mod_summary . tm_parsed_module
-  traceShowM ("tms", (map get_fp tcs))
+  Log.debugm $ "Typechecked modules for: " ++ (unlines $ map (show . get_fp) tcs)
   let findMod [] = Nothing
       findMod (x:xs) = case get_fp x of
                          Just fp -> if fp `isSuffixOf` (snd file) then Just x else findMod xs
@@ -87,13 +81,12 @@ updateTime ts graph = liftIO $ do
 setTargetFilesWithMessage :: (GhcMonad m)  => Maybe G.Messager -> [(FilePath, FilePath)] -> m ()
 setTargetFilesWithMessage msg files = do
     targets <- forM files guessTargetMapped
-    pprTrace "setTargets" (vcat (map (\(a,b) -> parens $ text a <+> text "," <+> text b) files) $$ ppr targets) (return ())
+    Log.debugm $ "setTargets: " ++ show files
     G.setTargets (map (\t -> t { G.targetAllowObjCode = False }) targets)
     mod_graph <- updateTime targets =<< depanal [] False
-    pprTrace "modGraph" (ppr $ Gap.mgModSummaries mod_graph) (return ())
-    pprTrace "modGraph" (ppr $ map ms_location $ Gap.mgModSummaries mod_graph) (return ())
+    Log.debugm $ "modGraph: " ++ show (map ms_location $ Gap.mgModSummaries mod_graph)
     dflags1 <- getSessionDynFlags
-    pprTrace "hidir" (ppr $ hiDir dflags1) (return ())
+    Log.debugm $ "hidir: " ++ show (hiDir dflags1)
     void $ G.load' LoadAllTargets msg mod_graph
 
 collectASTs :: (GhcMonad m) => m a -> m (a, [TypecheckedModule])
@@ -101,7 +94,7 @@ collectASTs action = do
   dflags0 <- getSessionDynFlags
   ref1 <- liftIO $ newIORef []
   let dflags1 = dflags0 { hooks = (hooks dflags0)
-                          { hscFrontendHook = traceShow "Use hook" $ Just (astHook ref1) }
+                          { hscFrontendHook = Just (astHook ref1) }
                         }
   -- Modify session is much faster than `setSessionDynFlags`.
   modifySession $ \h -> h{ hsc_dflags = dflags1 }

--- a/src/HIE/Bios/Log.hs
+++ b/src/HIE/Bios/Log.hs
@@ -1,0 +1,16 @@
+module HIE.Bios.Log where
+
+import Control.Monad.IO.Class
+import System.Log.Logger
+
+logm :: MonadIO m => String -> m ()
+logm s = liftIO $ infoM "hie-bios" s
+
+debugm :: MonadIO m => String -> m ()
+debugm s = liftIO $ debugM "hie-bios" s
+
+warningm :: MonadIO m => String -> m ()
+warningm s = liftIO $ warningM "hie-bios" s
+
+errorm :: MonadIO m => String -> m ()
+errorm s = liftIO $ errorM "hie-bios" s

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -159,21 +159,8 @@ data Cradle = Cradle {
 data CradleAction = CradleAction {
                       actionName :: String
                       -- ^ Name of the action
-                      , getDependencies :: IO [FilePath]
-                      -- ^ Dependencies of a cradle that might change the cradle.
-                      -- Contains both files specified in hie.yaml as well as
-                      -- specified by the build-tool if there is any.
-                      -- FilePaths are expected to be relative to the `cradleRootDir`
-                      -- to which this CradleAction belongs to.
-                      -- Files returned by this action might not actually exist.
-                      -- This is useful, because, sometimes, adding specific files
-                      -- changes the options that a Cradle may return, thus, needs reload
-                      -- as soon as these files are created.
-                      , getOptions :: FilePath -> IO (CradleLoadResult CompilerOptions)
+                      , runCradle :: FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
-                      -- The result consists of the return code of the operation
-                      -- that has been run, the stdout of the process, and a list of
-                      -- options that are needed to compile the given file.
                       }
 
 instance Show CradleAction where
@@ -191,6 +178,16 @@ instance Exception CradleError where
 ----------------------------------------------------------------
 
 -- | Option information for GHC
-data CompilerOptions = CompilerOptions {
-    ghcOptions  :: [String]  -- ^ Command line options
+data ComponentOptions = ComponentOptions {
+    componentOptions  :: [String]  -- ^ Command line options
+  , componentDependencies :: [FilePath]
+  -- ^ Dependencies of a cradle that might change the cradle.
+  -- Contains both files specified in hie.yaml as well as
+  -- specified by the build-tool if there is any.
+  -- FilePaths are expected to be relative to the `cradleRootDir`
+  -- to which this CradleAction belongs to.
+  -- Files returned by this action might not actually exist.
+  -- This is useful, because, sometimes, adding specific files
+  -- changes the options that a Cradle may return, thus, needs reload
+  -- as soon as these files are created.
   } deriving (Eq, Show)

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -21,6 +21,8 @@ main = defaultMain $
     assertParser "direct.yaml" (noDeps (Direct ["list", "of", "arguments"]))
     assertParser "none.yaml" (noDeps None)
     assertParser "obelisk.yaml" (noDeps Obelisk)
+    assertParser "multi.yaml" (noDeps (Multi [("./src", CradleConfig [] (Cabal (Just "lib:hie-bios")))
+                                             , ("./test", CradleConfig [] (Cabal (Just "test")) ) ]))
 
 
 

--- a/tests/configs/multi.yaml
+++ b/tests/configs/multi.yaml
@@ -1,0 +1,6 @@
+cradle:
+  multi:
+    - path: "./src"
+      config: { cradle: {cabal: {component: "lib:hie-bios"}} }
+    - path: "./test"
+      config: { cradle: {cabal: {component: "test"}} }


### PR DESCRIPTION
This patch isn't ready yet as it shows the API is slightly wrong in a few places. Specifically the dependencies API is not quite right, the `CradleAction` should also return the dependencies rather than being a separate function I believe so it can also depend on the `FilePath` as the dependencies may be totally different per component. 

Example config.

```
cradle:                                                                         
   multi:                                                                        
    - path: "./"                                                                
       config: { cradle: {cabal: {component: "lib:hie-bios"}} }  
```

Also it will be useless given the current behaviour of `ghcide` which just always passes the empty pass to the cradle. When it starts passing a more nuanced path and supports multiple components then this configuration may be more useful.
