### PR TITLE
Don't throw an error if the file to search from doesn't exist

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -422,7 +422,9 @@ findFileUpwards p dir = do
 
 -- | Sees if any file in the directory matches the predicate
 findFile :: (FilePath -> Bool) -> FilePath -> IO [FilePath]
-findFile p dir = getFiles >>= filterM doesPredFileExist
+findFile p dir = do
+  b <- doesDirectoryExist dir
+  if b then getFiles >>= filterM doesPredFileExist else return []
   where
     getFiles = filter p <$> getDirectoryContents dir
     doesPredFileExist file = doesFileExist $ dir </> file


### PR DESCRIPTION
In some cases LSP might be editing a file that hasn't yet been saved. I ran into this when trying to do better per-file LSP stuff for ghcide.