### PR TITLE
Cache windows executable wrapper 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist-newstyle/
 .stack-work/
 stack.yaml
 stack.yaml.lock
+cabal.project.local*

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -36,6 +36,7 @@ Library
                         HIE.Bios.Ghc.Load
                         HIE.Bios.Ghc.Logger
                         HIE.Bios.Ghc.Things
+  Other-Modules:        Paths_hie_bios
   Build-Depends:
                         base >= 4.8 && < 5,
                         base16-bytestring    >= 0.1.1 && < 0.2,

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -247,7 +247,7 @@ getCabalWrapperTool = do
             writeFile wrapper_hs cabalWrapperHs
             createDirectoryIfMissing True cacheDir
             let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
-                      { cwd = Just (takeDirectory wrapper_hs) }
+                        { cwd = Just (takeDirectory wrapper_hs) }
             readCreateProcess ghc "" >>= putStr
         return wrapper_fp
       else do

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -238,11 +238,13 @@ getCabalWrapperTool = do
     if isWindows
       then do
         cacheDir <- getXdgDirectory XdgCache "hie-bios"
-        let exeName = ("wrapper-" ++ showVersion version) <.> "exe"
-        let wrapper_fp = cacheDir </> exeName
+        let wrapper_name = "wrapper-" ++ showVersion version
+        let wrapper_fp = cacheDir </> wrapper_name <.> "exe"
         exists <- doesFileExist wrapper_fp
         unless exists $ do
-            wrapper_hs <- writeSystemTempFile "wrapper.hs" cabalWrapperHs
+            tempDir <- getTemporaryDirectory
+            let wrapper_hs = tempDir </> wrapper_name <.> "hs"
+            writeFile wrapper_hs cabalWrapperHs
             createDirectoryIfMissing True cacheDir
             let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
                       { cwd = Just (takeDirectory wrapper_hs) }


### PR DESCRIPTION
* Fixes #55
* Using $XDG_CACHE_HOME cache directory as suggested by @mpickering 
* I've used the `hie-bios` version to qualificate the wrapper:
  * We'll have not remember changing its own version if it changes
  * But it will create a 16 Mb executable for each minor version of the library
  * If it doesnt worth it i could use a specific version for it as suggested by @ndmitchell 
