### PR TITLE
Expose the the cradle config output

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -56,10 +56,8 @@ main = flip E.catches handlers $ do
     hSetEncoding stdout utf8
     args <- getArgs
     cradle <- getCurrentDirectory >>= \cwd ->
-        -- find cradle does a takeDirectory on the argument, so make it into a file
-        findCradle (cwd </> "File.hs") >>= \case
-          Just yaml -> loadCradle yaml
-          Nothing -> loadImplicitCradle (cwd </> "File.hs")
+        -- loadCradle does a takeDirectory on the argument, so make it into a file
+        loadCradle (cwd </> "File.hs")
     let cmdArg0 = args !. 0
         remainingArgs = tail args
         opt = defaultOptions

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -3,10 +3,8 @@
 module HIE.Bios (
   -- * Find and load a Cradle
     Cradle(..)
-  , findCradle
+  , cradleConfig
   , loadCradle
-  , loadImplicitCradle
-  , defaultCradle
   -- * Compiler Options
   , CompilerOptions(..)
   , getCompilerOptions


### PR DESCRIPTION
This restructures the code so that the selected configuration (whether a yaml-based or an implicit) is exposed in the API.

As a result of the rearrangement there is no longer any need to separately expose the implicit, default, and yaml cradle finding functions.

Basically, I want to use `hie-bios` to find the environment variables used while building a project for that I need access to the configuration it chooses.

I'm not entirely comfortable with the expected output, so if someone could test that these changes preserve behaviour, it would be great.