### PR TITLE
Change the Cradle to always use the Windows approach of an exe.

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -234,24 +234,20 @@ processCabalWrapperArgs args =
 -- command-line arguments and exit
 getCabalWrapperTool :: IO FilePath
 getCabalWrapperTool = do
-  wrapper_fp <-
-    if isWindows
-      then do
-        cacheDir <- getXdgDirectory XdgCache "hie-bios"
-        let wrapper_name = "wrapper-" ++ showVersion version
-        let wrapper_fp = cacheDir </> wrapper_name <.> "exe"
-        exists <- doesFileExist wrapper_fp
-        unless exists $ do
-            tempDir <- getTemporaryDirectory
-            let wrapper_hs = tempDir </> wrapper_name <.> "hs"
-            writeFile wrapper_hs cabalWrapperHs
-            createDirectoryIfMissing True cacheDir
-            let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
-                        { cwd = Just (takeDirectory wrapper_hs) }
-            readCreateProcess ghc "" >>= putStr
-        return wrapper_fp
-      else do
-        writeSystemTempFile "bios-wrapper" cabalWrapper
+  wrapper_fp <- do
+    cacheDir <- getXdgDirectory XdgCache "hie-bios"
+    let wrapper_name = "wrapper-" ++ showVersion version
+    let wrapper_fp = cacheDir </> wrapper_name <.> "exe"
+    exists <- doesFileExist wrapper_fp
+    unless exists $ do
+      tempDir <- getTemporaryDirectory
+      let wrapper_hs = tempDir </> wrapper_name <.> "hs"
+      writeFile wrapper_hs cabalWrapperHs
+      createDirectoryIfMissing True cacheDir
+      let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
+                  { cwd = Just (takeDirectory wrapper_hs) }
+      readCreateProcess ghc "" >>= putStr
+    turn wrapper_fp
 
   setFileMode wrapper_fp accessModes
   _check <- readFile wrapper_fp

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -247,7 +247,7 @@ getCabalWrapperTool = do
       let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
                   { cwd = Just (takeDirectory wrapper_hs) }
       readCreateProcess ghc "" >>= putStr
-    turn wrapper_fp
+    return wrapper_fp
 
   setFileMode wrapper_fp accessModes
   _check <- readFile wrapper_fp

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -4,15 +4,16 @@ import System.Directory (getCurrentDirectory)
 import System.Environment (getArgs)
 import System.Exit (exitWith)
 import System.Process (spawnProcess, waitForProcess)
+import Data.List (nub)
 
 main = do
   args <- getArgs
   case args of
     "--interactive":_ -> do
       getCurrentDirectory >>= putStrLn
-      putStrLn $ delimited args
+      putStrLn $ delimited $ nub args
     _ -> do
-      ph <- spawnProcess "ghc" args
+      ph <- spawnProcess "ghc" $ nub args
       code <- waitForProcess ph
       exitWith code
 


### PR DESCRIPTION
Change the wrapper code to dedup the GHC arguments, in large
Haskell codebases with many modules and projects we are seeing
the same GHC args repeated a ton (possibly per project? per module?).
Simplifies the approach, allows for more processing to happen on those
args.