### PR TITLE
Add cabal multi cradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ The complete configuration is a subset of
 cradle:
   cabal:
     component: "optional component name"
+  cabal:
+    - path: ./
+      component: "component name"
   stack:
   bazel:
   obelisk:
@@ -145,6 +148,10 @@ cradle:
 ```
 
 If a file matches multiple prefixes, the most specific one is chosen.
+Once a prefix is matched, the selected cradle is used to find the options. This
+is usually a specific cradle such as `cabal` or `stack` but it could be another
+multi-cradle, in which case, matching works in exactly the same way until a
+specific cradle is chosen.
 
 This cradle type is experimental and may not be supported correctly by
 some libraries which use `hie-bios`. It requires some additional care to
@@ -162,6 +169,31 @@ cradle:
       config: { cradle: {cabal: {component: "test"}} }
     - path: "./test/test-files"
       config: { cradle: none }
+```
+
+For cabal projects there is a shorthand to specify how to load each component.
+
+```
+cradle:
+  cabal:
+    - path: "./src"
+      component: "lib:hie-bios"
+    - path: "./test"
+      component: "test"
+```
+
+Remember you can combine this shorthand with more complicated configuration
+as well.
+
+```
+cradle:
+  multi:
+    - path: "./test/testdata"
+      config: { cradle: { none:  } }
+    - path: "./"
+      config: { cradle: { cabal:
+                            [ { path: "./src", component: "lib:hie-bios" }
+                            , { path: "./tests", component: "parser-tests" } ] } }
 ```
 
 

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -60,6 +60,11 @@ loadCradleWithOpts _copts wfile = do
 getCradle :: (CradleConfig, FilePath) -> Cradle
 getCradle (cc, wdir) = addCradleDeps cradleDeps $ case cradleType cc of
     Cabal mc -> cabalCradle wdir mc
+    CabalMulti ms ->
+      getCradle $
+        (CradleConfig cradleDeps
+          (Multi [(p, CradleConfig [] (Cabal (Just c))) | (p, c) <- ms])
+        , wdir)
     Stack -> stackCradle wdir
     Bazel -> rulesHaskellCradle wdir
     Obelisk -> obeliskCradle wdir

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -24,7 +24,13 @@ main = defaultMain $
     assertParser "multi.yaml" (noDeps (Multi [("./src", CradleConfig [] (Cabal (Just "lib:hie-bios")))
                                              , ("./test", CradleConfig [] (Cabal (Just "test")) ) ]))
 
+    assertParser "cabal-multi.yaml" (noDeps (CabalMulti [("./src", "lib:hie-bios")
+                                                    ,("./", "lib:hie-bios")]))
 
+    assertParser "nested-cabal-multi.yaml" (noDeps (Multi [("./test/testdata", CradleConfig [] None)
+                                                          ,("./", CradleConfig [] (
+                                                                    CabalMulti [("./src", "lib:hie-bios")
+                                                                               ,("./tests", "parser-tests")]))]))
 
 assertParser :: FilePath -> Config -> Assertion
 assertParser fp cc = do

--- a/tests/configs/cabal-multi.yaml
+++ b/tests/configs/cabal-multi.yaml
@@ -1,0 +1,6 @@
+cradle:
+  cabal:
+    - path: "./src"
+      component: "lib:hie-bios"
+    - path: "./"
+      component: "lib:hie-bios"

--- a/tests/configs/nested-cabal-multi.yaml
+++ b/tests/configs/nested-cabal-multi.yaml
@@ -1,0 +1,8 @@
+cradle:
+  multi:
+    - path: "./test/testdata"
+      config: { cradle: { none:  } }
+    - path: "./"
+      config: { cradle: { cabal:
+                            [ { path: "./src", component: "lib:hie-bios" }
+                            , { path: "./tests", component: "parser-tests" } ] } }


### PR DESCRIPTION
This new cradle type allows you to easily specify all the different parts of a cabal project without 
lots of boilerplate.

```
cradle:
  cabal:
    - path: "./src"
      component: "lib:hie-bios"
    - path: "./test"
      component: "test"
```