### PR TITLE
Only use an implicit Stack cradle if stack is executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The targets are searched for in following order.
 1. A specific `hie-bios` file.
 2. An `obelisk` project
 3. A `rules_haskell` project
-4. A `stack` project
+4. A `stack` project, if there exists an executable `stack` in `$PATH`
 5. A `cabal` project
 6. The default cradle which has no specific options.
 

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -91,7 +91,7 @@ implicitConfig' fp = (\wdir ->
          (Bios (wdir </> ".hie-bios") Nothing, wdir)) <$> biosWorkDir fp
      <|> (Obelisk,) <$> obeliskWorkDir fp
      <|> (Bazel,) <$> rulesHaskellWorkDir fp
-     <|> (Stack,) <$> stackWorkDir fp
+     <|> (stackExecutable >> (Stack,) <$> stackWorkDir fp)
      <|> ((Cabal Nothing,) <$> cabalWorkDir fp)
 
 
@@ -387,6 +387,8 @@ combineExitCodes = foldr go ExitSuccess
     go ExitSuccess b = b
     go a _ = a
 
+stackExecutable :: MaybeT IO FilePath
+stackExecutable = MaybeT $ findExecutable "stack"
 
 stackWorkDir :: FilePath -> MaybeT IO FilePath
 stackWorkDir = findFileUpwards isStack


### PR DESCRIPTION
This could certainly be done for the other cradles too