### PR TITLE
Filter out `-w` and `-v0` arguments from cabal wrapper

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -268,7 +268,8 @@ processCabalWrapperArgs args =
     case lines args of
         [dir, ghc_args] ->
             let final_args =
-                    removeInteractive
+                    removeVerbosityOpts
+                    $ removeInteractive
                     $ map (fixImportDirs dir)
                     $ limited ghc_args
             in Just final_args
@@ -328,6 +329,9 @@ cabalAction work_dir mc _fp = do
 
 removeInteractive :: [String] -> [String]
 removeInteractive = filter (/= "--interactive")
+
+removeVerbosityOpts :: [String] -> [String]
+removeVerbosityOpts = filter ((&&) <$> (/= "-v0") <*> (/= "-w"))
 
 fixImportDirs :: FilePath -> String -> String
 fixImportDirs base_dir arg =


### PR DESCRIPTION
If you pass `-v0` to cabal then it adds these options to the ghc
command line. This causes some unexpected consequences because `-w`
turns off ALL warnings, even default ones, such as the ones which warn
about deferred type errors.

https://github.com/digital-asset/ghcide/issues/170

Thanks to Andres for helping debug this.