### PR TITLE
Correctly parse the output from the bios executable

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -53,6 +53,7 @@ Library
                         process              >= 1.6.1 && < 1.7,
                         file-embed           >= 0.0.10 && < 0.1,
                         ghc                  >= 8.2.2 && < 8.9,
+                        shellwords           >= 0.1.2 && < 0.2,
                         transformers         >= 0.5.2 && < 0.6,
                         temporary            >= 1.2 && < 1.4,
                         text                 >= 1.2.3 && < 1.3,

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -22,6 +22,7 @@ import Data.FileEmbed
 import System.IO.Temp
 import Data.List
 import Data.Ord (Down(..))
+import qualified ShellWords as SW
 
 import System.PosixCompat.Files
 
@@ -227,10 +228,13 @@ biosAction :: FilePath
 biosAction _wdir bios bios_deps fp = do
   bios' <- canonicalizePath bios
   (ex, res, std) <- readProcessWithExitCode bios' [fp] []
+  let args = case SW.parse res of
+        Left err -> error err
+        Right tokens -> tokens
   deps <- biosDepsAction bios_deps
         -- Execute the bios action and add dependencies of the cradle.
         -- Removes all duplicates.
-  return $ makeCradleResult (ex, std, words res) deps
+  return $ makeCradleResult (ex, std, args) deps
 
 ------------------------------------------------------------------------
 -- Cabal Cradle


### PR DESCRIPTION
Multi-word arguments must be parsed correctly. E.g., currently `-flag
'foo bar'` is parsed as [-flag, 'foo, bar'].
It should be [-flag, 'foo bar'].

Use the shellwords package for that.