### PR TITLE
Need to export CradleLoadResult

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -1,5 +1,5 @@
 Name:                   hie-bios
-Version:                0.2.1
+Version:                0.3.0
 Author:                 Matthew Pickering <matthewtpickering@gmail.com>
 Maintainer:             Matthew Pickering <matthewtpickering@gmail.com>
 License:                BSD3

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -3,6 +3,7 @@
 module HIE.Bios (
   -- * Find and load a Cradle
     Cradle(..)
+  , CradleLoadResult(..)
   , findCradle
   , loadCradle
   , loadImplicitCradle


### PR DESCRIPTION
The return type of `getCompilerOptions` changed, so the major version of **hie-bios** needs to bump to n+1, in this case `0.3.0`

It's new return type, CradleLoadResult, needs to be exported. Done.