### PR TITLE
Add --test so that test dependencies are built

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -375,7 +375,7 @@ stackAction work_dir fp = do
   -- Same wrapper works as with cabal
   wrapper_fp <- getCabalWrapperTool
   (ex1, args, stde) <-
-      readProcessWithExitCodeInDirectory work_dir "stack" ["repl", "--silent", "--no-load", "--with-ghc", wrapper_fp, fp ] []
+      readProcessWithExitCodeInDirectory work_dir "stack" ["repl", "--silent", "--no-load", "--test", "--no-run-tests", "--with-ghc", wrapper_fp, fp ] []
   (ex2, pkg_args, stdr) <-
       readProcessWithExitCodeInDirectory work_dir "stack" ["path", "--ghc-package-path"] []
   let split_pkgs = splitSearchPath (init pkg_args)
@@ -383,7 +383,7 @@ stackAction work_dir fp = do
   deps <- stackCradleDependencies work_dir
   return $ case processCabalWrapperArgs args of
       Nothing -> CradleFail (CradleError ex1
-                  (unlines ["Failed to parse result of calling cabal"
+                  (unlines ["Failed to parse result of calling stack"
                            , stde
                            , args]))
 


### PR DESCRIPTION
I've been poking away at trying to solve #65 . My hypothesis is that all I need to do is add `--test --no-run-tests` (and maybe `--bench --no-run-benchmarks` for completeness) to `stackAction` and we're done?