### PR TITLE
Don't use stdout to communicate arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ cradle: {cabal: {component: "lib:haskell-ide-engine"}}
 Or you can explicitly state the program which should be used to collect
 the options by supplying the path to the program. It is interpreted
 relative to the current working directory if it is not an absolute path.
-The bios program should return a list of options separated by newline characters.
+The bios program should consult the `HIE_BIOS_OUTPUT` env var and write a list of
+options to this file separated by newlines. Once the program finishes running `hie-bios`
+reads this file and uses the arguments to set up the GHC session. This is how GHC's
+build system is able to support `hie-bios`.
 
 ```yaml
 cradle: {bios: {program: ".hie-bios"}}

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -16,7 +16,6 @@ import System.IO (hPutStr, hPutStrLn, stdout, stderr, hSetEncoding, utf8)
 import System.FilePath( (</>) )
 
 import HIE.Bios
-import HIE.Bios.Types
 import HIE.Bios.Ghc.Check
 import HIE.Bios.Internal.Debug
 import Paths_hie_bios

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -16,6 +16,7 @@ import System.IO (hPutStr, hPutStrLn, stdout, stderr, hSetEncoding, utf8)
 import System.FilePath( (</>) )
 
 import HIE.Bios
+import HIE.Bios.Types
 import HIE.Bios.Ghc.Check
 import HIE.Bios.Internal.Debug
 import Paths_hie_bios

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -37,6 +37,7 @@ Library
                         HIE.Bios.Ghc.Gap
                         HIE.Bios.Ghc.Load
                         HIE.Bios.Ghc.Logger
+                        HIE.Bios.Wrappers
   Other-Modules:        Paths_hie_bios
   Build-Depends:
                         base >= 4.8 && < 5,
@@ -50,7 +51,6 @@ Library
                         time                 >= 1.8.0 && < 1.10,
                         extra                >= 1.6.14 && < 1.7,
                         process              >= 1.6.1 && < 1.7,
-                        file-embed           >= 0.0.10 && < 0.1,
                         ghc                  >= 8.2.2 && < 8.9,
                         transformers         >= 0.5.2 && < 0.6,
                         temporary            >= 1.2 && < 1.4,
@@ -59,7 +59,10 @@ Library
                         unordered-containers >= 0.2.9 && < 0.3,
                         vector               >= 0.12.0 && < 0.13,
                         yaml                 >= 0.8.32 && < 0.12,
-                        hslogger             >= 1.2 && < 1.4
+                        hslogger             >= 1.2 && < 1.4,
+                        file-embed           >= 0.0.11 && < 1,
+                        conduit              >= 1.3 && < 2,
+                        conduit-extra        >= 1.3 && < 2
 
 
 Executable hie-bios

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -373,7 +373,7 @@ stackAction work_dir l fp = do
   -- Same wrapper works as with cabal
   wrapper_fp <- getCabalWrapperTool
   (ex1, _stdo, stde, args) <-
-      readProcessWithOutputFile l work_dir "stack" ["repl", "--no-load", "--with-ghc", wrapper_fp, fp ]
+      readProcessWithOutputFile l work_dir "stack" ["repl", "--no-nix-pure", "--no-load", "--with-ghc", wrapper_fp, fp ]
   (ex2, pkg_args, stdr, _) <-
     readProcessWithOutputFile l work_dir "stack" ["path", "--ghc-package-path"]
   let split_pkgs = concatMap splitSearchPath pkg_args

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -520,11 +520,11 @@ readProcessWithOutputFile l work_dir fp args = withSystemTempFile "bios-output" 
   let process = (proc fp args) { cwd = Just work_dir
                                , env = Just (("HIE_BIOS_OUTPUT", output_file) : old_env)
                                }
-      loggingConduit = (C.decodeUtf8  C..| C.lines C..| C.map unpack C..| C.iterM l C..| C.sinkList)
+      -- Windows line endings are not converted so you have to filter out `'r` characters
+      loggingConduit = (C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')  C..| C.map unpack C..| C.iterM l C..| C.sinkList)
   (ex, stdo, stde) <- sourceProcessWithStreams process mempty loggingConduit loggingConduit
   !res <- force <$> hGetContents h
   return (ex, stdo, stde, lines res)
-
 
 
 makeCradleResult :: (ExitCode, [String], [String]) -> [FilePath] -> CradleLoadResult ComponentOptions

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -524,7 +524,7 @@ readProcessWithOutputFile l work_dir fp args = withSystemTempFile "bios-output" 
       loggingConduit = (C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')  C..| C.map unpack C..| C.iterM l C..| C.sinkList)
   (ex, stdo, stde) <- sourceProcessWithStreams process mempty loggingConduit loggingConduit
   !res <- force <$> hGetContents h
-  return (ex, stdo, stde, lines res)
+  return (ex, stdo, stde, lines (filter (/= '\r') res))
 
 
 makeCradleResult :: (ExitCode, [String], [String]) -> [FilePath] -> CradleLoadResult ComponentOptions

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -1,6 +1,7 @@
 module HIE.Bios.Flags (getCompilerOptions) where
 
 import HIE.Bios.Types
+import HIE.Bios.Internal.Log
 
 
 -- | Initialize the 'DynFlags' relating to the compilation of a single
@@ -10,7 +11,7 @@ getCompilerOptions ::
     -> Cradle
     -> IO (CradleLoadResult ComponentOptions)
 getCompilerOptions fp cradle =
-  runCradle (cradleOptsProg cradle) fp
+  runCradle (cradleOptsProg cradle) logm fp
 
 
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -7,6 +7,7 @@ import Data.Maybe (fromMaybe)
 
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Types
+import HIE.Bios.Flags
 
 ----------------------------------------------------------------
 
@@ -21,7 +22,7 @@ import HIE.Bios.Types
 debugInfo :: Cradle
           -> IO String
 debugInfo cradle = unlines <$> do
-    res <- runCradle (cradleOptsProg cradle) (cradleRootDir cradle)
+    res <- getCompilerOptions (cradleRootDir cradle) cradle
     case res of
       CradleSuccess (ComponentOptions gopts deps) -> do
         mglibdir <- liftIO getSystemLibDir
@@ -34,7 +35,7 @@ debugInfo cradle = unlines <$> do
       CradleFail (CradleError ext stderr) ->
         return ["Cradle failed to load"
                , "Exit Code: " ++ show ext
-               , "Stderr: " ++ stderr]
+               , "Stderr: " ++ unlines stderr]
       CradleNone ->
         return ["No cradle"]
   where

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -39,10 +39,12 @@ data Cradle = Cradle {
   , cradleOptsProg   :: CradleAction
   } deriving (Show)
 
+type LoggingFunction = String -> IO ()
+
 data CradleAction = CradleAction {
                       actionName :: String
                       -- ^ Name of the action.
-                      , runCradle :: FilePath -> IO (CradleLoadResult ComponentOptions)
+                      , runCradle :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
                       }
 
@@ -58,7 +60,7 @@ data CradleLoadResult r = CradleSuccess r -- ^ The cradle succeeded and returned
                       deriving (Functor)
 
 
-data CradleError = CradleError ExitCode String deriving (Show)
+data CradleError = CradleError ExitCode [String] deriving (Show)
 
 instance Exception CradleError where
 ----------------------------------------------------------------

--- a/src/HIE/Bios/Wrappers.hs
+++ b/src/HIE/Bios/Wrappers.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+module HIE.Bios.Wrappers (cabalWrapper, cabalWrapperHs) where
+
+import Data.FileEmbed
+
+cabalWrapper :: String
+cabalWrapper = $(embedStringFile "wrappers/cabal")
+
+cabalWrapperHs :: String
+cabalWrapperHs = $(embedStringFile "wrappers/cabal.hs")

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
+
+function out(){
+  echo "$1" >> $HIE_BIOS_OUTPUT
+}
+
 if [ "$1" == "--interactive" ]; then
-  pwd
+  pwd | out
   for arg in "$@"; do
-    echo -ne "$arg\x00"
+    out "$arg"
   done
-  echo -ne "\n"
 else
   ghc "$@"
 fi

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -1,20 +1,21 @@
 module Main (main) where
 
 import System.Directory (getCurrentDirectory)
-import System.Environment (getArgs)
+import System.Environment (getArgs, getEnv)
 import System.Exit (exitWith)
 import System.Process (spawnProcess, waitForProcess)
+import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
 
 main = do
   args <- getArgs
+  output_file <- getEnv "HIE_BIOS_OUTPUT"
   case args of
     "--interactive":_ -> do
-      getCurrentDirectory >>= putStrLn
-      putStrLn $ delimited args
+      h <- openFile output_file AppendMode
+      getCurrentDirectory >>= hPutStrLn h
+      mapM_ (hPutStrLn h) args
+      hClose h
     _ -> do
       ph <- spawnProcess "ghc" args
       code <- waitForProcess ph
       exitWith code
-
-delimited :: [String] -> String
-delimited = concatMap (++ "\NUL")


### PR DESCRIPTION
Now all the cradles communicate by reading the value of HIE_BIOS_OUTPUT
which is a filepath, and writing the arguments to that temporary file.
This makes all the cradles more robust about the build tools spurting
things to stdout.