### PR TITLE
Fix `fixImportDirs`

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -339,7 +339,7 @@ fixImportDirs :: FilePath -> String -> String
 fixImportDirs base_dir arg =
   if "-i" `isPrefixOf` arg
     then let dir = drop 2 arg
-         in if isRelative dir then ("-i" ++ base_dir ++ "/" ++ dir)
+         in if not (null dir) && isRelative dir then "-i" ++ base_dir </> dir
                               else arg
     else arg
 


### PR DESCRIPTION
Use platform independent pathSeparator instead of "/".

Add additional check to avoid expanding "-i" to "-i<pwd>"
since "-i" means: "Empty the import directory list"

Reference: https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/flags.html#finding-imports