### PR TITLE
Add optional component to stack cradle and multi-stack

### DIFF
--- a/src/HIE/Bios/Config.hs
+++ b/src/HIE/Bios/Config.hs
@@ -51,7 +51,7 @@ data CradleType
 
 instance FromJSON CradleType where
     parseJSON (Object o) = parseCradleType o
-    parseJSON _ = fail "Not a known cradle type. Possible are: cabal, stack, bazel, obelisk, bios, direct, default, none, multi"
+    parseJSON _ = fail "Not a known cradle type. Possible are: cabal, stack, bios, direct, default, none, multi"
 
 parseCradleType :: Object -> Parser CradleType
 parseCradleType o
@@ -89,7 +89,7 @@ parseStackOrCabal _ multiConstructor (Array x) = do
 
   xs <- foldrM (\v cs -> (: cs) <$> parseOne v) [] x
   return $ multiConstructor xs
-
+parseStackOrCabal singleConstructor _ Null = return $ singleConstructor Nothing
 parseStackOrCabal _ _ _ = fail "Configuration is expected to be an object."
 
 parseStack :: Value -> Parser CradleType

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -34,8 +34,10 @@ import Data.Conduit.Process
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit as C
 import qualified Data.Conduit.Text as C
-import Data.Text (unpack)
-import           Data.Maybe                     ( maybeToList )
+import qualified Data.Text as T
+import           Data.Maybe                     ( maybeToList
+                                                , fromMaybe
+                                                )
 ----------------------------------------------------------------
 
 -- | Given root\/foo\/bar.hs, return root\/hie.yaml, or wherever the yaml file was found.
@@ -232,7 +234,7 @@ biosWorkDir = findFileUpwards (".hie-bios" ==)
 biosDepsAction :: LoggingFunction -> FilePath -> Maybe FilePath -> IO [FilePath]
 biosDepsAction l wdir (Just biosDepsProg) = do
   biosDeps' <- canonicalizePath biosDepsProg
-  (ex, sout, serr, args) <- readProcessWithOutputFile l wdir biosDeps' []
+  (ex, sout, serr, args) <- readProcessWithOutputFile l Nothing wdir biosDeps' []
   case ex of
     ExitFailure _ ->  error $ show (ex, sout, serr)
     ExitSuccess -> return args
@@ -246,7 +248,7 @@ biosAction :: FilePath
            -> IO (CradleLoadResult ComponentOptions)
 biosAction wdir bios bios_deps l fp = do
   bios' <- canonicalizePath bios
-  (ex, _stdo, std, res) <- readProcessWithOutputFile l wdir bios' [fp]
+  (ex, _stdo, std, res) <- readProcessWithOutputFile l Nothing wdir bios' [fp]
   deps <- biosDepsAction l wdir bios_deps
         -- Output from the program should be written to the output file and
         -- delimited by newlines.
@@ -292,11 +294,16 @@ processCabalWrapperArgs args =
             in Just final_args
         _ -> Nothing
 
+-- | GHC process information.
+-- Consists of the filepath to the ghc executable and
+-- arguments to the executable.
+type GhcProc = (FilePath, [String])
+
 -- generate a fake GHC that can be passed to cabal
 -- when run with --interactive, it will print out its
 -- command-line arguments and exit
-getCabalWrapperTool :: IO FilePath
-getCabalWrapperTool = do
+getCabalWrapperTool :: GhcProc -> IO FilePath
+getCabalWrapperTool (ghcPath, ghcArgs) = do
   wrapper_fp <-
     if isWindows
       then do
@@ -309,7 +316,7 @@ getCabalWrapperTool = do
             let wrapper_hs = tempDir </> wrapper_name <.> "hs"
             writeFile wrapper_hs cabalWrapperHs
             createDirectoryIfMissing True cacheDir
-            let ghc = (proc "ghc" ["-o", wrapper_fp, wrapper_hs])
+            let ghc = (proc ghcPath $ ghcArgs ++ ["-o", wrapper_fp, wrapper_hs])
                         { cwd = Just (takeDirectory wrapper_hs) }
             readCreateProcess ghc "" >>= putStr
         return wrapper_fp
@@ -321,11 +328,11 @@ getCabalWrapperTool = do
 
 cabalAction :: FilePath -> Maybe String -> LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
 cabalAction work_dir mc l _fp = do
-  wrapper_fp <- getCabalWrapperTool
+  wrapper_fp <- getCabalWrapperTool ("ghc", [])
   let cab_args = ["v2-repl", "--with-compiler", wrapper_fp]
                   ++ [component_name | Just component_name <- [mc]]
   (ex, output, stde, args) <-
-    readProcessWithOutputFile l work_dir "cabal" cab_args
+    readProcessWithOutputFile l Nothing work_dir "cabal" cab_args
   deps <- cabalCradleDependencies work_dir
   case processCabalWrapperArgs args of
       Nothing -> pure $ CradleFail (CradleError ex
@@ -376,12 +383,15 @@ stackCradleDependencies wdir = do
 
 stackAction :: FilePath -> Maybe String -> LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
 stackAction work_dir mc l _fp = do
+  let ghcProcArgs = ("stack", ["exec", "ghc", "--"])
   -- Same wrapper works as with cabal
-  wrapper_fp <- getCabalWrapperTool
+  wrapper_fp <- getCabalWrapperTool ghcProcArgs
+
   (ex1, _stdo, stde, args) <-
-      readProcessWithOutputFile l work_dir "stack" $ ["repl", "--no-nix-pure", "--no-load", "--with-ghc", wrapper_fp] ++ maybeToList mc
+    readProcessWithOutputFile l Nothing work_dir
+            "stack" $ ["repl", "--no-nix-pure", "--with-ghc", wrapper_fp] ++ maybeToList mc
   (ex2, pkg_args, stdr, _) <-
-    readProcessWithOutputFile l work_dir "stack" ["path", "--ghc-package-path"]
+    readProcessWithOutputFile l Nothing work_dir "stack" ["path", "--ghc-package-path"]
   let split_pkgs = concatMap splitSearchPath pkg_args
       pkg_ghc_args = concatMap (\p -> ["-package-db", p] ) split_pkgs
   deps <- stackCradleDependencies work_dir
@@ -391,7 +401,8 @@ stackAction work_dir mc l _fp = do
                     stde)
                    ++ args)
 
-      Just ghc_args -> makeCradleResult (combineExitCodes [ex1, ex2], stde ++ stdr, ghc_args ++ pkg_ghc_args) deps
+      Just ghc_args ->
+        makeCradleResult (combineExitCodes [ex1, ex2], stde ++ stdr, ghc_args ++ pkg_ghc_args) deps
 
 combineExitCodes :: [ExitCode] -> ExitCode
 combineExitCodes = foldr go ExitSuccess
@@ -506,32 +517,54 @@ findFile p dir = do
     getFiles = filter p <$> getDirectoryContents dir
     doesPredFileExist file = doesFileExist $ dir </> file
 
--- | Call a process with the given arguments
+-- | Call a process with the given arguments.
 -- * A special file is created for the process to write to, the process can discover the name of
 -- the file by reading the @HIE_BIOS_OUTPUT@ environment variable. The contents of this file is
 -- returned by the function.
 -- * The logging function is called every time the process emits anything to stdout or stderr.
 -- it can be used to report progress of the process to a user.
--- * The process is executed in the given directory
+-- * The process is executed in the given directory.
+-- * The path to the GHC version to use is supplied in the environment variable @HIE_BIOS_GHC@.
+--   Additionally, arguments to ghc are supplied via @HIE_BIOS_GHC_ARGS@
 readProcessWithOutputFile
-  :: LoggingFunction
-  -> FilePath
-  -> FilePath
-  -> [String]
+  :: LoggingFunction -- ^ Output of the process is streamed into this function.
+  -> Maybe GhcProc -- ^ Optional FilePath to GHC and arguments that should
+                   -- be passed to ghc.
+                   -- In the process to call, filepath and arguments
+  -> FilePath -- ^ Working directory. Process is executed in this directory.
+  -> FilePath -- ^ Process to call.
+  -> [String] -- ^ Arguments to the process.
   -> IO (ExitCode, [String], [String], [String])
-readProcessWithOutputFile l work_dir fp args = withSystemTempFile "bios-output" $ \output_file h -> do
-  hSetBuffering h LineBuffering
-  old_env <- getEnvironment
-  -- Pipe stdout directly into the logger
-  let process = (proc fp args) { cwd = Just work_dir
-                               , env = Just (("HIE_BIOS_OUTPUT", output_file) : old_env)
-                               }
-      -- Windows line endings are not converted so you have to filter out `'r` characters
-      loggingConduit = (C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')  C..| C.map unpack C..| C.iterM l C..| C.sinkList)
-  (ex, stdo, stde) <- sourceProcessWithStreams process mempty loggingConduit loggingConduit
-  !res <- force <$> hGetContents h
-  return (ex, stdo, stde, lines (filter (/= '\r') res))
+readProcessWithOutputFile l ghcProc work_dir fp args =
+  withSystemTempFile "bios-output" $ \output_file h -> do
+    hSetBuffering h LineBuffering
+    old_env <- getEnvironment
+    let (ghcPath, ghcArgs) = case ghcProc of
+            Just (p, a) -> (p, unwords a)
+            Nothing ->
+              ( fromMaybe "ghc" (lookup hieBiosGhc old_env)
+              , fromMaybe "" (lookup hieBiosGhcArgs old_env)
+              )
+    -- Pipe stdout directly into the logger
+    let process = (readProcessInDirectory work_dir fp args)
+                      { env = Just
+                              $ (hieBiosGhc, ghcPath)
+                              : (hieBiosGhcArgs, ghcArgs)
+                              : ("HIE_BIOS_OUTPUT", output_file)
+                              : old_env
+                      }
+        -- Windows line endings are not converted so you have to filter out `'r` characters
+        loggingConduit = (C.decodeUtf8  C..| C.lines C..| C.filterE (/= '\r')  C..| C.map T.unpack C..| C.iterM l C..| C.sinkList)
+    (ex, stdo, stde) <- sourceProcessWithStreams process mempty loggingConduit loggingConduit
+    !res <- force <$> hGetContents h
+    return (ex, stdo, stde, lines (filter (/= '\r') res))
 
+    where
+      hieBiosGhc = "HIE_BIOS_GHC"
+      hieBiosGhcArgs = "HIE_BIOS_GHC_ARGS"
+
+readProcessInDirectory :: FilePath -> FilePath -> [String] -> CreateProcess
+readProcessInDirectory wdir p args = (proc p args) { cwd = Just wdir }
 
 makeCradleResult :: (ExitCode, [String], [String]) -> [FilePath] -> CradleLoadResult ComponentOptions
 makeCradleResult (ex, err, gopts) deps =

--- a/src/HIE/Bios/Wrappers.hs
+++ b/src/HIE/Bios/Wrappers.hs
@@ -9,3 +9,4 @@ cabalWrapper = $(embedStringFile "wrappers/cabal")
 
 cabalWrapperHs :: String
 cabalWrapperHs = $(embedStringFile "wrappers/cabal.hs")
+

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -33,8 +33,6 @@ main = do
         ]
       , testGroup "Loading tests" [
         testCaseSteps "simple-cabal" $ testDirectory "./tests/projects/simple-cabal/B.hs"
-        -- The stack tests don't attempt to load the targets initially because they are not returned
-        -- by `stack repl`. They are hidden inside a GHCi script.
         , testCaseSteps "simple-stack" $ testDirectory "./tests/projects/simple-stack/B.hs"
         , testCaseSteps "simple-direct" $ testDirectory "./tests/projects/simple-direct/B.hs"
         , testCaseSteps "simple-bios" $ testDirectory "./tests/projects/simple-bios/B.hs"
@@ -68,7 +66,7 @@ testDirectory fp step = do
           liftIO (step "Initial module load")
           sf <- ini
           case sf of
-            -- Test resetting the targets, and also has the effect on stack of actually loading any targets.
+            -- Test resetting the targets
             Succeeded -> setTargetFilesWithMessage (Just (\_ n _ _ -> step (show n))) [(a_fp, a_fp)]
             Failed -> error "Module loading failed"
         CradleNone -> error "None"

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 
 import Test.Tasty
@@ -6,44 +7,45 @@ import HIE.Bios
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Load
 import Control.Monad.IO.Class
-import Control.Monad ( unless )
+import Control.Monad ( unless, forM_ )
 import System.Directory
-import System.FilePath ( makeRelative )
-import BasicTypes
+import System.FilePath ( makeRelative, (</>) )
 
 main :: IO ()
-main = defaultMain $
-  testGroup "Bios-tests"
-    [ testGroup "Find cradle"
-      [ testCaseSteps "simple-cabal"
-              (findCradleForModule
-                "./tests/projects/simple-cabal/B.hs"
-                (Just "./tests/projects/simple-cabal/hie.yaml")
-              )
+main = do
+  writeStackYamlFiles
+  defaultMain $
+    testGroup "Bios-tests"
+      [ testGroup "Find cradle"
+        [ testCaseSteps "simple-cabal"
+                (findCradleForModule
+                  "./tests/projects/simple-cabal/B.hs"
+                  (Just "./tests/projects/simple-cabal/hie.yaml")
+                )
 
-      -- Checks if we can find a hie.yaml even when the given filepath
-      -- is unknown. This functionality is required by Haskell IDE Engine.
-      , testCaseSteps "simple-cabal-unknown-path"
-              (findCradleForModule
-                "./tests/projects/simple-cabal/Foo.hs"
-                (Just "./tests/projects/simple-cabal/hie.yaml")
-              )
+        -- Checks if we can find a hie.yaml even when the given filepath
+        -- is unknown. This functionality is required by Haskell IDE Engine.
+        , testCaseSteps "simple-cabal-unknown-path"
+                (findCradleForModule
+                  "./tests/projects/simple-cabal/Foo.hs"
+                  (Just "./tests/projects/simple-cabal/hie.yaml")
+                )
+        ]
+      , testGroup "Loading tests" [
+        testCaseSteps "simple-cabal" $ testDirectory "./tests/projects/simple-cabal/B.hs"
+        -- The stack tests don't attempt to load the targets initially because they are not returned
+        -- by `stack repl`. They are hidden inside a GHCi script.
+        , testCaseSteps "simple-stack" $ testDirectory "./tests/projects/simple-stack/B.hs"
+        , testCaseSteps "simple-direct" $ testDirectory "./tests/projects/simple-direct/B.hs"
+        , testCaseSteps "simple-bios" $ testDirectory "./tests/projects/simple-bios/B.hs"
+        , testCaseSteps "multi-cabal" {- tests if both components can be loaded -}
+                      $  testDirectory "./tests/projects/multi-cabal/app/Main.hs"
+                      >> testDirectory "./tests/projects/multi-cabal/src/Lib.hs"
+        , testCaseSteps "multi-stack" {- tests if both components can be loaded -}
+                      $  testDirectory "./tests/projects/multi-stack/app/Main.hs"
+                      >> testDirectory "./tests/projects/multi-stack/src/Lib.hs"
+        ]
       ]
-    , testGroup "Loading tests" [
-      testCaseSteps "simple-cabal" $ testDirectory "./tests/projects/simple-cabal/B.hs"
-      -- The stack tests don't attempt to load the targets initially because they are not returned
-      -- by `stack repl`. They are hidden inside a GHCi script.
-      , testCaseSteps "simple-stack" $ testDirectory "./tests/projects/simple-stack/B.hs"
-      , testCaseSteps "simple-direct" $ testDirectory "./tests/projects/simple-direct/B.hs"
-      , testCaseSteps "simple-bios" $ testDirectory "./tests/projects/simple-bios/B.hs"
-      , testCaseSteps "multi-cabal" {- tests if both components can be loaded -}
-                    $  testDirectory "./tests/projects/multi-cabal/app/Main.hs"
-                    >> testDirectory "./tests/projects/multi-cabal/src/Lib.hs"
-      , testCaseSteps "multi-stack" {- tests if both components can be loaded -}
-                    $  testDirectory "./tests/projects/multi-stack/app/Main.hs"
-                    >> testDirectory "./tests/projects/multi-stack/src/Lib.hs"
-      ]
-  ]
 
 
 
@@ -84,3 +86,35 @@ findCradleForModule fp expected' step = do
     ++ show expected
     ++ ", Actual: "
     ++ show mcfg
+
+
+writeStackYamlFiles :: IO ()
+writeStackYamlFiles = do
+  let yamlFile = stackYaml stackYamlResolver
+  forM_ stackProjects $ \proj ->
+    writeFile (proj </> "stack.yaml") yamlFile
+
+stackProjects :: [FilePath]
+stackProjects =
+  [ "tests" </> "projects" </> "multi-stack"
+  , "tests" </> "projects" </> "simple-stack"
+  ]
+
+stackYaml :: String -> String
+stackYaml resolver = unlines ["resolver: " ++ resolver, "packages:", "- ."]
+
+stackYamlResolver :: String
+stackYamlResolver =
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,8,1,0)))
+  "nightly-2019-12-13"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,6,5,0)))
+  "lts-14.17"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,6,4,0)))
+  "lts-13.19"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,4,0)))
+  "lts-12.26"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,3,0)))
+  "lts-12.26"
+#elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
+  "lts-11.22"
+#endif

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -12,7 +12,7 @@ main :: IO ()
 main = defaultMain $
   testCase "Parser Tests" $ do
     assertParser "cabal-1.yaml" (noDeps (Cabal (Just "lib:hie-bios")))
-    assertParser "stack-config.yaml" (noDeps Stack)
+    assertParser "stack-config.yaml" (noDeps (Stack Nothing))
     --assertParser "bazel.yaml" (noDeps Bazel)
     assertParser "bios-1.yaml" (noDeps (Bios "program" Nothing))
     assertParser "bios-2.yaml" (noDeps (Bios "program" (Just "dep-program")))
@@ -26,10 +26,18 @@ main = defaultMain $
     assertParser "cabal-multi.yaml" (noDeps (CabalMulti [("./src", "lib:hie-bios")
                                                     ,("./", "lib:hie-bios")]))
 
+    assertParser "stack-multi.yaml" (noDeps (StackMulti [("./src", "lib:hie-bios")
+                                                    ,("./", "lib:hie-bios")]))
+
     assertParser "nested-cabal-multi.yaml" (noDeps (Multi [("./test/testdata", CradleConfig [] None)
                                                           ,("./", CradleConfig [] (
                                                                     CabalMulti [("./src", "lib:hie-bios")
                                                                                ,("./tests", "parser-tests")]))]))
+
+    assertParser "nested-stack-multi.yaml" (noDeps (Multi [("./test/testdata", CradleConfig [] None)
+                                                          ,("./", CradleConfig [] (
+                                                                    StackMulti [("./src", "lib:hie-bios")
+                                                                              ,("./tests", "parser-tests")]))]))
 
 assertParser :: FilePath -> Config -> Assertion
 assertParser fp cc = do

--- a/tests/configs/nested-stack-multi.yaml
+++ b/tests/configs/nested-stack-multi.yaml
@@ -1,0 +1,8 @@
+cradle:
+  multi:
+    - path: "./test/testdata"
+      config: { cradle: { none:  } }
+    - path: "./"
+      config: { cradle: { stack:
+                            [ { path: "./src", component: "lib:hie-bios" }
+                            , { path: "./tests", component: "parser-tests" } ] } }

--- a/tests/configs/stack-config.yaml
+++ b/tests/configs/stack-config.yaml
@@ -1,2 +1,2 @@
 cradle:
-  { stack: }
+  { stack: {}}

--- a/tests/configs/stack-multi.yaml
+++ b/tests/configs/stack-multi.yaml
@@ -1,0 +1,6 @@
+cradle:
+  stack:
+    - path: "./src"
+      component: "lib:hie-bios"
+    - path: "./"
+      component: "lib:hie-bios"

--- a/tests/projects/multi-stack/hie.yaml
+++ b/tests/projects/multi-stack/hie.yaml
@@ -1,2 +1,7 @@
 cradle:
   stack:
+      - path: ./src
+        component: "multi-stack:lib"
+
+      - path: ./app
+        component: "multi-stack:exe:multi-stack"

--- a/tests/projects/simple-stack/hie.yaml
+++ b/tests/projects/simple-stack/hie.yaml
@@ -1,2 +1,3 @@
 cradle:
-  stack: {}
+  stack:
+    component: "simple-stack:lib"

--- a/tests/projects/simple-stack/simple-stack.cabal
+++ b/tests/projects/simple-stack/simple-stack.cabal
@@ -1,5 +1,5 @@
 cabal-version:       >=2.0
-name:                simple-cabal
+name:                simple-stack
 version:             0.1.0.0
 -- synopsis:
 -- description:

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -10,5 +10,5 @@ if [ "$1" == "--interactive" ]; then
     out "$arg"
   done
 else
-  ghc "$@"
+  "${HIE_BIOS_GHC}" ${HIE_BIOS_GHC_ARGS} "$@"
 fi

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -9,6 +9,8 @@ import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
 main = do
   args <- getArgs
   output_file <- getEnv "HIE_BIOS_OUTPUT"
+  ghcPath <- getEnv "HIE_BIOS_GHC"
+  ghcPathArgs <- fmap unwords (getEnv "HIE_BIOS_GHC_ARGS")
   case args of
     "--interactive":_ -> do
       h <- openFile output_file AppendMode
@@ -16,6 +18,6 @@ main = do
       mapM_ (hPutStrLn h) args
       hClose h
     _ -> do
-      ph <- spawnProcess "ghc" args
+      ph <- spawnProcess ghcPath (ghcPathArgs ++ args)
       code <- waitForProcess ph
       exitWith code


### PR DESCRIPTION
Closes #96 

* [x]  Don't pass a FilePath to the cradle, rely on the magic all component logic
* [x]  Add an option to specify a specific component, like the cabal cradle
* [x] Simple parsing of the ghci script to file :add and :load targets.
