### PR TITLE
debug: Make it take an optional explicit filepath

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -64,7 +64,9 @@ main = flip E.catches handlers $ do
         remainingArgs = tail args
     res <- case cmdArg0 of
       "check"   -> checkSyntax cradle remainingArgs
-      "debug"   -> debugInfo cradle
+      "debug"
+        | null remainingArgs -> debugInfo (cradleRootDir cradle) cradle
+        | (fp:_) <- remainingArgs -> debugInfo fp cradle
       "root"    -> rootInfo cradle
       "version" -> return progVersion
       "flags"

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -19,10 +19,11 @@ import HIE.Bios.Flags
 -- the file dependencies and so on.
 --
 -- Otherwise, shows the error message and exit-code.
-debugInfo :: Cradle
+debugInfo :: FilePath
+          -> Cradle
           -> IO String
-debugInfo cradle = unlines <$> do
-    res <- getCompilerOptions (cradleRootDir cradle) cradle
+debugInfo fp cradle = unlines <$> do
+    res <- getCompilerOptions fp cradle
     case res of
       CradleSuccess (ComponentOptions gopts deps) -> do
         mglibdir <- liftIO getSystemLibDir


### PR DESCRIPTION
This makes it work much better for testing the multi-cradle.