### PR TITLE
Add debug commands to show the location of the yaml file

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -72,20 +72,8 @@ main = flip E.catches handlers $ do
         | (fp:_) <- remainingArgs -> debugInfo fp cradle
       "root"    -> rootInfo cradle
       "version" -> return progVersion
-      "config"
-        | null remainingArgs -> return "No files given"
-        | otherwise -> fmap unlines $ forM remainingArgs $ \fp ->
-            findCradle (cwd </> fp) >>= \case
-              Just yaml -> return $ "Config for \"" ++ fp ++ "\": " ++ yaml
-              _ -> return $ "Config for \"" ++ fp ++ "\": Not Found"
-      "cradle"
-        | null remainingArgs -> return "No files given"
-        | otherwise -> fmap unlines $ forM remainingArgs $ \fp ->
-            findCradle (cwd </> fp) >>= \case
-              Just yaml -> do
-                crdl <- loadCradle yaml
-                return $ "Cradle for \"" ++ fp ++ "\": " ++ show crdl
-              _ -> return $ "Cradle for \"" ++ fp ++ "\": Not Found"
+      "config" -> configInfo remainingArgs
+      "cradle" -> cradleInfo remainingArgs
       "flags"
         | null remainingArgs -> E.throw $ NotEnoughArguments cmdArg0
         | otherwise -> do

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -35,6 +35,8 @@ usage =    progVersion
         ++ "\t hie-bios expand <HaskellFiles...>\n"
         ++ "\t hie-bios flags <HaskellFiles...>\n"
         ++ "\t hie-bios debug [<ComponentDir>]\n"
+        ++ "\t hie-bios config <HaskellFiles...>\n"
+        ++ "\t hie-bios cradle <HaskellFiles...>\n"
         ++ "\t hie-bios root\n"
         ++ "\t hie-bios version\n"
 
@@ -55,7 +57,8 @@ main :: IO ()
 main = flip E.catches handlers $ do
     hSetEncoding stdout utf8
     args <- getArgs
-    cradle <- getCurrentDirectory >>= \cwd ->
+    cwd <- getCurrentDirectory
+    cradle <-
         -- find cradle does a takeDirectory on the argument, so make it into a file
         findCradle (cwd </> "File.hs") >>= \case
           Just yaml -> loadCradle yaml
@@ -69,6 +72,20 @@ main = flip E.catches handlers $ do
         | (fp:_) <- remainingArgs -> debugInfo fp cradle
       "root"    -> rootInfo cradle
       "version" -> return progVersion
+      "config"
+        | null remainingArgs -> return "No files given"
+        | otherwise -> fmap unlines $ forM remainingArgs $ \fp ->
+            findCradle (cwd </> fp) >>= \case
+              Just yaml -> return $ "Config for \"" ++ fp ++ "\": " ++ yaml
+              _ -> return $ "Config for \"" ++ fp ++ "\": Not Found"
+      "cradle"
+        | null remainingArgs -> return "No files given"
+        | otherwise -> fmap unlines $ forM remainingArgs $ \fp ->
+            findCradle (cwd </> fp) >>= \case
+              Just yaml -> do
+                crdl <- loadCradle yaml
+                return $ "Cradle for \"" ++ fp ++ "\": " ++ show crdl
+              _ -> return $ "Cradle for \"" ++ fp ++ "\": Not Found"
       "flags"
         | null remainingArgs -> E.throw $ NotEnoughArguments cmdArg0
         | otherwise -> do

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -1,13 +1,19 @@
-module HIE.Bios.Internal.Debug (debugInfo, rootInfo) where
+{-# LANGUAGE LambdaCase #-}
+module HIE.Bios.Internal.Debug (debugInfo, rootInfo, configInfo, cradleInfo) where
 
 import Control.Monad.IO.Class (liftIO)
+import Control.Monad
 
 import qualified Data.Char as Char
 import Data.Maybe (fromMaybe)
 
 import HIE.Bios.Ghc.Api
+import HIE.Bios.Cradle
 import HIE.Bios.Types
 import HIE.Bios.Flags
+
+import System.Directory
+import System.FilePath
 
 ----------------------------------------------------------------
 
@@ -24,6 +30,8 @@ debugInfo :: FilePath
           -> IO String
 debugInfo fp cradle = unlines <$> do
     res <- getCompilerOptions fp cradle
+    conf <- findConfig fp
+    crdl <- findCradle' fp
     case res of
       CradleSuccess (ComponentOptions gopts deps) -> do
         mglibdir <- liftIO getSystemLibDir
@@ -31,6 +39,8 @@ debugInfo fp cradle = unlines <$> do
             "Root directory:      " ++ rootDir
           , "GHC options:         " ++ unwords (map quoteIfNeeded gopts)
           , "System libraries:    " ++ fromMaybe "" mglibdir
+          , "Config Location:     " ++ conf
+          , "Cradle:              " ++ crdl
           , "Dependencies:        " ++ unwords deps
           ]
       CradleFail (CradleError ext stderr) ->
@@ -51,3 +61,35 @@ debugInfo fp cradle = unlines <$> do
 rootInfo :: Cradle
           -> IO String
 rootInfo cradle = return $ cradleRootDir cradle
+
+----------------------------------------------------------------
+
+configInfo :: [FilePath] -> IO String
+configInfo []   = return "No files given"
+configInfo args = do
+  cwd <- getCurrentDirectory
+  fmap unlines $ forM args $ \fp ->
+    (("Config for \"" ++ fp ++ "\": ") ++) <$> findConfig (cwd </> fp)
+
+findConfig :: FilePath -> IO String
+findConfig fp = findCradle fp >>= \case
+  Just yaml -> return yaml
+  _ -> return "No explicit config found"
+
+----------------------------------------------------------------
+
+cradleInfo :: [FilePath] -> IO String
+cradleInfo [] = return "No files given"
+cradleInfo args = do
+  cwd <- getCurrentDirectory
+  fmap unlines $ forM args $ \fp ->
+    (("Cradle for \"" ++ fp ++ "\": ") ++)  <$> findCradle' (cwd </> fp)
+
+findCradle' :: FilePath -> IO String
+findCradle' fp = findCradle fp >>= \case
+  Just yaml -> do
+    crdl <- loadCradle yaml
+    return $ show crdl
+  Nothing -> do
+    crdl <- loadImplicitCradle fp
+    return $ show crdl


### PR DESCRIPTION
Adds the commands 

* `config` to show the location of the `hie.yaml` to which the given filepath belongs to.
* `cradle` to show the serialized `hie.yaml` to which the given filepath belongs to.

I think commands similar to these are good to help debugging when you want to know which filepath is actually associated to which hie.yaml.

Example call:
```
> hie-bios config wrappers/cabal.hs
Config for "wrappers/cabal.hs": /home/baldr/Documents/haskell/hie-bios/hie.yaml
```