### PR TITLE
Fix wrapper to default to no ghc arguments and execute compilation in cradle dir

### DIFF
--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -1,7 +1,7 @@
 module Main (main) where
 
 import System.Directory (getCurrentDirectory)
-import System.Environment (getArgs, getEnv)
+import System.Environment (getArgs, getEnv, lookupEnv)
 import System.Exit (exitWith)
 import System.Process (spawnProcess, waitForProcess)
 import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
@@ -10,7 +10,7 @@ main = do
   args <- getArgs
   output_file <- getEnv "HIE_BIOS_OUTPUT"
   ghcPath <- getEnv "HIE_BIOS_GHC"
-  ghcPathArgs <- fmap words (getEnv "HIE_BIOS_GHC_ARGS")
+  ghcPathArgs <- fmap (maybe [] words) (lookupEnv "HIE_BIOS_GHC_ARGS")
   case args of
     "--interactive":_ -> do
       h <- openFile output_file AppendMode


### PR DESCRIPTION
In the wrapper, if the env variable `HIE_BIOS_GHC_ARGS` is set to `""`, in windows, this seems to throw an exception. Fix it by using `lookupEnv` and adding a default value.

Also, mainly for stack exec, execute `stack exec ghc --` in the working directory of the cradle, to avoid that the global project is used for compilation.

Manually tested on windows for cabal in wsl, stack not yet.
EDIT: apparently I wasnt using the wsl but rather in mingw32? or cygwin? Not sure, to many artifacts of previous attempts to turn the windows device into a dev machine.