### PR TITLE
Make wrapper name unique using its source hash

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -313,9 +313,9 @@ getCabalWrapperTool (ghcPath, ghcArgs) wdir = do
         let wrapper_fp = cacheDir </> wrapper_name <.> "exe"
         exists <- doesFileExist wrapper_fp
         unless exists $ withSystemTempDirectory "hie-bios" $ \ tmpDir -> do
+            createDirectoryIfMissing True cacheDir
             let wrapper_hs = cacheDir </> wrapper_name <.> "hs"
             writeFile wrapper_hs cabalWrapperHs
-            createDirectoryIfMissing True cacheDir
             let ghc = (proc ghcPath $
                         ghcArgs ++ ["-outputdir", tmpDir, "-o", wrapper_fp, wrapper_hs])
                         { cwd = Just wdir }

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -28,8 +28,6 @@ import HIE.Bios.Wrappers
 import System.IO
 import Control.DeepSeq
 
-import Data.Version (showVersion)
-import Paths_hie_bios
 import Data.Conduit.Process
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit as C
@@ -38,6 +36,7 @@ import qualified Data.Text as T
 import           Data.Maybe                     ( maybeToList
                                                 , fromMaybe
                                                 )
+import           GHC.Fingerprint (fingerprintString)
 ----------------------------------------------------------------
 
 -- | Given root\/foo\/bar.hs, return root\/hie.yaml, or wherever the yaml file was found.
@@ -307,9 +306,11 @@ getCabalWrapperTool (ghcPath, ghcArgs) wdir = do
   wrapper_fp <-
     if isWindows
       then do
+        mbEnvCacheDir <- lookupEnv "HIE_BIOS_CACHE_DIR"
         cacheDir <- getXdgDirectory XdgCache "hie-bios"
-        let wrapper_name = "wrapper-" ++ showVersion version
-        let wrapper_fp = cacheDir </> wrapper_name <.> "exe"
+        let wrapper_dir = fromMaybe cacheDir mbEnvCacheDir
+        let wrapper_name = "wrapper-" ++ show (fingerprintString cabalWrapperHs)
+        let wrapper_fp = wrapper_dir </> wrapper_name <.> "exe"
         exists <- doesFileExist wrapper_fp
         unless exists $ do
             tempDir <- getTemporaryDirectory

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RecordWildCards, CPP #-}
-module HIE.Bios.Environment (initSession, getSystemLibDir, addCmdOpts) where
+module HIE.Bios.Environment (initSession, getSystemLibDir, getCacheDir, addCmdOpts) where
 
 import CoreMonad (liftIO)
 import GHC (DynFlags(..), GhcLink(..), HscTarget(..), GhcMonad)
@@ -13,6 +13,7 @@ import Control.Monad (void)
 import System.Process (readProcess)
 import System.Directory
 import System.FilePath
+import System.Environment (lookupEnv)
 
 import qualified Crypto.Hash.SHA1 as H
 import qualified Data.ByteString.Char8 as B
@@ -76,7 +77,11 @@ however, it's not really necessary as
 >   when res (removeDirectoryRecursive cd)
 -}
 getCacheDir :: FilePath -> IO FilePath
-getCacheDir fp = getXdgDirectory XdgCache (cacheDir </> fp)
+getCacheDir fp = do
+  mbEnvCacheDirectory <- lookupEnv "HIE_BIOS_CACHE_DIR"
+  cacheBaseDir <- maybe (getXdgDirectory XdgCache cacheDir) return
+                         mbEnvCacheDirectory
+  return (cacheBaseDir </> fp)
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -76,6 +76,10 @@ however, it's not really necessary as
 >   res <- doesPathExist cd
 >   when res (removeDirectoryRecursive cd)
 -}
+
+-- | Prepends the cache directory used by the library to the supplied file path.
+-- It tries to use the path under the environment variable `$HIE_BIOS_CACHE_DIR` 
+-- and falls back to the standard `$XDG_CACHE_HOME/hie-bios` if the former is not set
 getCacheDir :: FilePath -> IO FilePath
 getCacheDir fp = do
   mbEnvCacheDirectory <- lookupEnv "HIE_BIOS_CACHE_DIR"


### PR DESCRIPTION
* Before this the wrapper used the project version to cache the wrapper executable
* That led to false negatives testing the compilation and execution of the wrapper using the `bios-test` test suite cause the tests reused a previous wrapper executable between commits of the same version
  * Devs had to remember delete manually `%XDG_DIRECTORY%\hie-bios` to avoid it
* I've used `GHC.Fingerprint` to hash the source file and cache the executable using  its source (the most accurate one although non semantic changes will cause a cache miss)
  * And i've put the source near the executable to be able to check it quicky without have to go to hie-bios source 

* I've cherry-picked my changes onto `0.3.0` and `0.3.1` to check the test suite with them:
  * `0.3.0`: https://ci.appveyor.com/project/jneira/hie-bios/builds/29673096/job/9x5k66k9ittfyvy0
  * `0.3.1`: https://ci.appveyor.com/project/jneira/hie-bios/builds/29673244/job/nxkbys8o1gt737vq
* In both cases the test suite fails. 
  * To be fair it had failed in the windows ci without these changes cause we are not caching `%XDG_DIRECTORY%\hie-bios` between ci builds and the wrapper would be compiled every time.
  * But if we start caching `%XDG_DIRECTORY%\hie-bios` in ci for some reason it will suffer the false negatives as well
* I am using a new en var `%HIE_BIOS_CACHE_DIR%` to let users change the default one (without change the general `%XDG_CACHEDIR%`). It is not strictly necessary but it is a common practice to avoid issues with file permissions (in some envs the creation of executable files inside user directory is forbidden f.e.) 
  
Fixes #114