### PR TITLE
Add explicit cradle predicates and multi cradle depend on its cradles

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, LambdaCase #-}
+{-# LANGUAGE DeriveDataTypeable, LambdaCase, ScopedTypeVariables #-}
 
 module Main where
 
@@ -9,6 +9,7 @@ import qualified Control.Exception as E
 import Control.Monad ( forM )
 import Data.Typeable (Typeable)
 import Data.Version (showVersion)
+import Data.Void
 import System.Directory (getCurrentDirectory)
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
@@ -58,7 +59,7 @@ main = flip E.catches handlers $ do
     hSetEncoding stdout utf8
     args <- getArgs
     cwd <- getCurrentDirectory
-    cradle <-
+    cradle :: Cradle Void <-
         -- find cradle does a takeDirectory on the argument, so make it into a file
         findCradle (cwd </> "File.hs") >>= \case
           Just yaml -> loadCradle yaml

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -31,6 +31,9 @@ Extra-Source-Files:     ChangeLog
                         tests/configs/obelisk.yaml
                         tests/configs/stack-config.yaml
                         tests/configs/stack-multi.yaml
+                        tests/projects/multi-direct/A.hs
+                        tests/projects/multi-direct/B.hs
+                        tests/projects/multi-direct/hie.yaml
                         tests/projects/multi-cabal/Setup.hs
                         tests/projects/multi-cabal/app/Main.hs
                         tests/projects/multi-cabal/cabal.project

--- a/src/HIE/Bios/Flags.hs
+++ b/src/HIE/Bios/Flags.hs
@@ -8,7 +8,7 @@ import HIE.Bios.Internal.Log
 -- file or GHC session according to the provided 'Cradle'.
 getCompilerOptions ::
     FilePath -- The file we are loading it because of
-    -> Cradle
+    -> Cradle a
     -> IO (CradleLoadResult ComponentOptions)
 getCompilerOptions fp cradle =
   runCradle (cradleOptsProg cradle) logm fp

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -62,7 +62,7 @@ withGhcT body = do
 initializeFlagsWithCradle ::
     GhcMonad m
     => FilePath -- ^ The file we are loading the 'Cradle' because of
-    -> Cradle   -- ^ The cradle we want to load
+    -> Cradle a   -- ^ The cradle we want to load
     -> m (CradleLoadResult (m G.SuccessFlag))
 initializeFlagsWithCradle = initializeFlagsWithCradleWithMessage (Just G.batchMsg)
 
@@ -73,7 +73,7 @@ initializeFlagsWithCradleWithMessage ::
   GhcMonad m
   => Maybe G.Messager
   -> FilePath -- ^ The file we are loading the 'Cradle' because of
-  -> Cradle   -- ^ The cradle we want to load
+  -> Cradle a  -- ^ The cradle we want to load
   -> m (CradleLoadResult (m G.SuccessFlag)) -- ^ Whether we actually loaded the cradle or not.
 initializeFlagsWithCradleWithMessage msg fp cradle =
     fmap (initSessionWithMessage msg) <$> (liftIO $ getCompilerOptions fp cradle)

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -23,7 +23,8 @@ import HIE.Bios.Environment
 
 -- | Checking syntax of a target file using GHC.
 --   Warnings and errors are returned.
-checkSyntax :: Cradle
+checkSyntax :: Show a
+            => Cradle a
             -> [FilePath]  -- ^ The target files.
             -> IO String
 checkSyntax _      []    = return ""

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -3,6 +3,7 @@ module HIE.Bios.Internal.Debug (debugInfo, rootInfo, configInfo, cradleInfo) whe
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad
+import Data.Void
 
 import qualified Data.Char as Char
 import Data.Maybe (fromMaybe)
@@ -13,7 +14,6 @@ import HIE.Bios.Types
 import HIE.Bios.Flags
 
 import System.Directory
-import System.FilePath
 
 ----------------------------------------------------------------
 
@@ -25,8 +25,9 @@ import System.FilePath
 -- the file dependencies and so on.
 --
 -- Otherwise, shows the error message and exit-code.
-debugInfo :: FilePath
-          -> Cradle
+debugInfo :: Show a
+          => FilePath
+          -> Cradle a
           -> IO String
 debugInfo fp cradle = unlines <$> do
     res <- getCompilerOptions fp cradle
@@ -59,7 +60,7 @@ debugInfo fp cradle = unlines <$> do
 ----------------------------------------------------------------
 
 -- | Get the root directory of the given Cradle.
-rootInfo :: Cradle
+rootInfo :: Cradle a
           -> IO String
 rootInfo cradle = return $ cradleRootDir cradle
 
@@ -90,8 +91,8 @@ findCradle' :: FilePath -> IO String
 findCradle' fp =
   findCradle fp >>= \case
     Just yaml -> do
-      crdl <- loadCradle yaml
+      crdl <- loadCradle yaml :: IO (Cradle Void)
       return $ show crdl
     Nothing -> do
-      crdl <- loadImplicitCradle fp
+      crdl <- loadImplicitCradle fp :: IO (Cradle Void)
       return $ show crdl

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -31,33 +31,45 @@ defaultCradleOpts = CradleOpts Silent Nothing
 --
 -- A 'Cradle' may be a single unit in the \"cabal-install\" context, or
 -- the whole package, comparable to how \"stack\" works.
-data Cradle = Cradle {
+data Cradle a = Cradle {
   -- | The project root directory.
     cradleRootDir    :: FilePath
   -- | The action which needs to be executed to get the correct
   -- command line arguments.
-  , cradleOptsProg   :: CradleAction
+  , cradleOptsProg   :: CradleAction a
   } deriving (Show)
 
 type LoggingFunction = String -> IO ()
 
-data CradleAction = CradleAction {
-                      actionName :: String
+data ActionName a
+  = Stack
+  | Cabal
+  | Bios
+  | Default
+  | Multi
+  | Direct
+  | None
+  | Other a
+  deriving (Show, Eq, Ord)
+
+data CradleAction a = CradleAction {
+                      actionName :: ActionName a
                       -- ^ Name of the action.
                       , runCradle :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
                       }
 
-instance Show CradleAction where
-  show CradleAction { actionName = name } = "CradleAction: " ++ name
+instance Show a => Show (CradleAction a) where
+  show CradleAction { actionName = name } = "CradleAction: " ++ show name
 
 -- | Result of an attempt to set up a GHC session for a 'Cradle'.
 -- This is the go-to error handling mechanism. When possible, this
 -- should be preferred over throwing exceptions.
-data CradleLoadResult r = CradleSuccess r -- ^ The cradle succeeded and returned these options.
-                      | CradleFail CradleError -- ^ We tried to load the cradle and it failed.
-                      | CradleNone -- ^ No attempt was made to load the cradle.
-                      deriving (Functor)
+data CradleLoadResult r
+  = CradleSuccess r -- ^ The cradle succeeded and returned these options.
+  | CradleFail CradleError -- ^ We tried to load the cradle and it failed.
+  | CradleNone -- ^ No attempt was made to load the cradle.
+  deriving (Functor)
 
 
 data CradleError = CradleError ExitCode [String] deriving (Show)

--- a/tests/projects/multi-direct/A.hs
+++ b/tests/projects/multi-direct/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/tests/projects/multi-direct/B.hs
+++ b/tests/projects/multi-direct/B.hs
@@ -1,0 +1,3 @@
+module B where
+
+import A

--- a/tests/projects/multi-direct/hie.yaml
+++ b/tests/projects/multi-direct/hie.yaml
@@ -1,0 +1,12 @@
+cradle:
+  multi:
+    - path: "A.hs"
+      config:
+        cradle:
+          direct:
+            arguments: ["-Walaaal", "A", "B"]
+    - path: "B.hs"
+      config:
+        cradle:
+          direct:
+            arguments: ["-Walaaal", "A", "B"]


### PR DESCRIPTION
This changes multi-cradles to have the name `stack` or `cabal` if their hie.yaml specification solely consists of `stack` or `cabal` and `none` cradles. To make stuff easier, we add `is*Cradle` predicates to the API. Users of this library can make use of them to obtain the cradle-type after it has been parsed.

Fixes https://github.com/haskell/haskell-ide-engine/issues/1490

Also, changes the `ActionName` to be an extensible ADT.