### PR TITLE
Pass filepath to cabal v2-repl when getting flags

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -328,10 +328,9 @@ getCabalWrapperTool (ghcPath, ghcArgs) wdir = do
   return wrapper_fp
 
 cabalAction :: FilePath -> Maybe String -> LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
-cabalAction work_dir mc l _fp = do
+cabalAction work_dir _mc l fp = do
   wrapper_fp <- getCabalWrapperTool ("ghc", []) work_dir
-  let cab_args = ["v2-repl", "--with-compiler", wrapper_fp]
-                  ++ [component_name | Just component_name <- [mc]]
+  let cab_args = ["v2-repl", "--with-compiler", wrapper_fp, fp]
   (ex, output, stde, args) <-
     readProcessWithOutputFile l Nothing work_dir "cabal" cab_args
   deps <- cabalCradleDependencies work_dir

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -13,7 +13,6 @@ import HIE.Bios.Types
 import HIE.Bios.Flags
 
 import System.Directory
-import System.FilePath
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Instead of component. This lets Cabal figure out what component the module is in and should give more reliable flags for modules living outside of the specified component.