### PR TITLE
Expose initSessionWithMessage

### DIFF
--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -3,6 +3,7 @@
 module HIE.Bios.Ghc.Api (
     initializeFlagsWithCradle
   , initializeFlagsWithCradleWithMessage
+  , initSessionWithMessage
   , G.SuccessFlag(..)
   -- * Utility functions for running the GHC monad and implementing internal utilities
   , withGHC


### PR DESCRIPTION
Needed by https://github.com/haskell/haskell-ide-engine/pull/1589

Github and vim automatically added the newline so I gave up. 