### PR TITLE
Derive Ord for ComponentOptions

### DIFF
--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -90,4 +90,4 @@ data ComponentOptions = ComponentOptions {
   -- This is useful, because, sometimes, adding specific files
   -- changes the options that a Cradle may return, thus, needs reload
   -- as soon as these files are created.
-  } deriving (Eq, Show)
+  } deriving (Eq, Ord, Show)


### PR DESCRIPTION
This is useful for keeping maps indexed by ComponentOptions which we
want to use for caching in ghcide.