### PR TITLE
Bugfix: don't mangle GHC options that begin with "-i" (e.g. "-instantiated-with")

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -454,11 +454,18 @@ removeVerbosityOpts = filter ((&&) <$> (/= "-v0") <*> (/= "-w"))
 
 fixImportDirs :: FilePath -> String -> String
 fixImportDirs base_dir arg =
-  if "-i" `isPrefixOf` arg
+  if "-i" `isPrefixOf` arg && not (any (`isPrefixOf` arg) ghcOptionsThatBeginWithI)
     then let dir = drop 2 arg
          in if not (null dir) && isRelative dir then "-i" ++ base_dir </> dir
                               else arg
     else arg
+  where
+    -- If we assume that e.g. "-instantiated-with" means "-i./stanstiated-with",
+    -- GHC gets rather confused!
+    ghcOptionsThatBeginWithI =
+      [ "-ignore-package"
+      , "-instantiated-with"
+      , "-include-pkg-deps" ]
 
 
 cabalWorkDir :: FilePath -> MaybeT IO FilePath

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -454,7 +454,8 @@ removeVerbosityOpts = filter ((&&) <$> (/= "-v0") <*> (/= "-w"))
 
 fixImportDirs :: FilePath -> String -> String
 fixImportDirs base_dir arg =
-  if "-i" `isPrefixOf` arg && not (any (`isPrefixOf` arg) ghcOptionsThatBeginWithI)
+  if "-i" `isPrefixOf` arg &&
+     not (isGhcOptionThatBeginsWithI arg)
     then let dir = drop 2 arg
          in if not (null dir) && isRelative dir then "-i" ++ base_dir </> dir
                               else arg
@@ -462,10 +463,13 @@ fixImportDirs base_dir arg =
   where
     -- If we assume that e.g. "-instantiated-with" means "-i./stanstiated-with",
     -- GHC gets rather confused!
-    ghcOptionsThatBeginWithI =
-      [ "-ignore-package"
-      , "-instantiated-with"
-      , "-include-pkg-deps" ]
+    isGhcOptionThatBeginsWithI a =
+      -- We use `isPrefixOf` here in order to also catch
+      -- "-instantiated-with=..." and the like.
+      any (`isPrefixOf` a)
+        [ "-ignore-package"
+        , "-instantiated-with"
+        , "-include-pkg-deps" ]
 
 
 cabalWorkDir :: FilePath -> MaybeT IO FilePath


### PR DESCRIPTION
The 'fixImportDirs' function inadvertently catches GHC options that *begin* with "-i", such as "-instantiated-with" and "-ignore-package", and changes them to e.g. "-i/Users/foo/stantiated-with". This patch fixes that.

This bit me when I was trying to use ghcide with a Cabal package that has two module signatures: `BaseMonad.hsig` and `List.hsig`. I would get this error:

```
target ‘BaseMonad=<BaseMonad>,List=<List>’ is not a module name or a source file
```

This error occurred because Cabal was trying to pass `instantiated-with BaseMonad=<BaseMonad>,List=<List>` to GHC, but `fixImportDirs` had turned that into `-i/Users/parsonyorick/…/nstantiated-with BaseMonad=<BaseMonad>,List=<List>`, which GHC parsed as two commandline arguments.