### PR TITLE
Add component root directory

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 NEXT
 	* Add getCompilerOptionsWithLogger convenience function.
+	* Add componentRoot to ComponentOptions. [#166](https://github.com/mpickering/hie-bios/pull/166)
+		Options may be relative to the componentRoot.
+	* Add makeDynFlagsAbsolute to fix mangling of ghc options starting with "-i". [#166](https://github.com/mpickering/hie-bios/pull/166)
+		Breaks backwards-compatibility, because ComponentOptions now may contain
+		filepaths relative to the component root directory.
+		This function needs to be invoked on the parsed 'DynFlags' to normalise the filepaths.
 
 2020-01-29 - 0.4.0
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -86,6 +86,7 @@ main = flip E.catches handlers $ do
                                                 ++ "\": " ++ show err
                     CradleSuccess opts ->
                       return $ unlines ["Options: " ++ show (componentOptions opts)
+                                       ,"ComponentDir: " ++ (componentRoot opts)
                                        ,"Dependencies: " ++ show (componentDependencies opts) ]
                     CradleNone -> return "No flags: this component should not be loaded"
         return (unlines res)

--- a/src/HIE/Bios/Ghc/Gap.hs
+++ b/src/HIE/Bios/Ghc/Gap.hs
@@ -8,6 +8,7 @@ module HIE.Bios.Ghc.Gap (
   , getTyThing
   , fixInfo
   , getModSummaries
+  , mapOverIncludePaths
   , LExpression
   , LBinding
   , LPattern
@@ -20,7 +21,7 @@ module HIE.Bios.Ghc.Gap (
   , unsetLogAction
   ) where
 
-import DynFlags (DynFlags)
+import DynFlags (DynFlags, includePaths)
 import GHC(LHsBind, LHsExpr, LPat, Type, ModSummary, ModuleGraph, HscEnv, setLogAction, GhcMonad)
 import Outputable (PrintUnqualified, PprStyle, Depth(AllTheWay), mkUserStyle)
 
@@ -46,6 +47,7 @@ import GHC (mgModSummaries, mapMG)
 import GHC.Hs.Extension (GhcTc)
 import GHC.Hs.Expr (MatchGroup, MatchGroupTc(..), mg_ext)
 #elif __GLASGOW_HASKELL__ >= 806
+import DynFlags (IncludeSpecs(..))
 import HsExtension (GhcTc)
 import HsExpr (MatchGroup, MatchGroupTc(..))
 import GHC (mg_ext)
@@ -89,6 +91,20 @@ getTyThing (t,_,_,_,_) = t
 fixInfo :: (a, b, c, d, e) -> (a, b, c, d)
 fixInfo (t,f,cs,fs,_) = (t,f,cs,fs)
 #endif
+
+----------------------------------------------------------------
+
+mapOverIncludePaths :: (FilePath -> FilePath) -> DynFlags -> DynFlags
+mapOverIncludePaths f df = df
+  { includePaths = 
+#if __GLASGOW_HASKELL__ > 804
+      IncludeSpecs
+          (map f $ includePathsQuote  (includePaths df))
+          (map f $ includePathsGlobal (includePaths df))
+#else
+      map f (includePaths df)
+#endif
+  }
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -35,10 +35,11 @@ debugInfo fp cradle = unlines <$> do
     conf <- findConfig canonFp
     crdl <- findCradle' canonFp
     case res of
-      CradleSuccess (ComponentOptions gopts deps) -> do
+      CradleSuccess (ComponentOptions gopts croot deps) -> do
         mglibdir <- liftIO getSystemLibDir
         return [
             "Root directory:      " ++ rootDir
+          , "Component directory: " ++ croot
           , "GHC options:         " ++ unwords (map quoteIfNeeded gopts)
           , "System libraries:    " ++ fromMaybe "" mglibdir
           , "Config Location:     " ++ conf

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -81,6 +81,9 @@ instance Exception CradleError where
 -- | Option information for GHC
 data ComponentOptions = ComponentOptions {
     componentOptions  :: [String]  -- ^ Command line options.
+  , componentRoot :: FilePath 
+  -- ^ Root directory of the component. All 'componentOptions' are either 
+  -- absolute, or relative to this directory.
   , componentDependencies :: [FilePath]
   -- ^ Dependencies of a cradle that might change the cradle.
   -- Contains both files specified in hie.yaml as well as


### PR DESCRIPTION
Supersedes https://github.com/mpickering/hie-bios/pull/157

Implements the suggestion to wait until GHC is done parsing its flag to modify certain filepaths in DynFlags if they arent already absolute paths. 

Con: Ghc options now may contain relative filepaths.
Pro: fixes bugs.