### PR TITLE
Avoid error in windows due to temp file being locked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist-newstyle/
 stack.yaml
 stack.yaml.lock
 cabal.project.local*
+.vscode/

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -645,7 +645,8 @@ readProcessWithOutputFile l ghcProc work_dir fp args = do
             ( fromMaybe "ghc" (lookup hieBiosGhc old_env)
             , fromMaybe "" (lookup hieBiosGhcArgs old_env)
             )
-  output_file <- emptySystemTempFile "hie-bios"
+  output_file <- maybe (emptySystemTempFile "hie-bios") return
+                       (lookup hieBiosOutput old_env)
 
   -- Pipe stdout directly into the logger
   let process = (readProcessInDirectory work_dir fp args)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -675,9 +675,12 @@ readProcessWithOutputFile l ghcProc work_dir fp args = do
       withHieBiosOutput env action = do
         let mbHieBiosOut = lookup hieBiosOutput env
         case mbHieBiosOut of
-          Just file -> action file
-          Nothing -> withSystemTempDirectory "hie-bios" $ 
-                      \ tmpDir -> action $ tmpDir </> "output"
+          Just file@(_:_) -> action file
+          _ -> withTempHieBiosOutput action
+
+      withTempHieBiosOutput action = 
+        withSystemTempDirectory "hie-bios" $ 
+          \ tmpDir -> action $ tmpDir </> "output"
 
       hieBiosGhc = "HIE_BIOS_GHC"
       hieBiosGhcArgs = "HIE_BIOS_GHC_ARGS"


### PR DESCRIPTION
* In the process to use hie-bios on ghc i hit a problem when the hie-bios script tried to write in `%HIE_BIOS_OUTPUT$`: the file was locked by the executable and the script could not write in it
  * As usual in posis systems the lock works in a way the process started by hie-bios can write 
* Now the file es created but it is not opened until the process has used it. It is not deleted auto when it finishes but i thin kit is no a big problem, being a temporal file (but i could add a deleting)
* I've changed the handling of %HIE_BIOS_OUTPUT$` to honour the possible previous value set by the user: maybe it can be used if users pnly have permissions over concrete directories or they want to keep the compiler args in a file controled by them