### PR TITLE
Use implicit-hie

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: 706c15c2627ffe232a3e109611ec66a35c45360c
+    tag: bacaa2350e388a32283e04b5d33bcdb05d10a673

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: 48c33baf84d612f1ad126e636ddec21f61b88f0e
+    tag: b794a576b70ce5d0e81d34eb66b142df1bc8fd71

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: bacaa2350e388a32283e04b5d33bcdb05d10a673
+    tag: e033a562a8b18878d354b91977dbcd33604ad554

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: b794a576b70ce5d0e81d34eb66b142df1bc8fd71
+    tag: 58d729310b9eb627e7e1dfcc3e42862cf1606e44

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,6 @@
 packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/Avi-D-coder/implicit-hie.git
+    tag: 706c15c2627ffe232a3e109611ec66a35c45360c

--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,4 @@ packages: .
 source-repository-package
     type: git
     location: https://github.com/Avi-D-coder/implicit-hie.git
-    tag: e033a562a8b18878d354b91977dbcd33604ad554
+    tag: 48c33baf84d612f1ad126e636ddec21f61b88f0e

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -137,7 +137,8 @@ Library
                         hslogger             >= 1.2 && < 1.4,
                         file-embed           >= 0.0.11 && < 1,
                         conduit              >= 1.3 && < 2,
-                        conduit-extra        >= 1.3 && < 2
+                        conduit-extra        >= 1.3 && < 2,
+                        implicit-hie
 
 
 Executable hie-bios


### PR DESCRIPTION
Replaces implicit cradle logic with implicit-hie.
changes default to cabal over stack, since stack cannot load a cradle with a type error.