### PR TITLE
Remove unused environment variables to simplify code

### DIFF
--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -10,5 +10,5 @@ if [ "$1" == "--interactive" ]; then
     out "$arg"
   done
 else
-  "${HIE_BIOS_GHC}" ${HIE_BIOS_GHC_ARGS} "$@"
+  "ghc" "$@"
 fi

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -9,8 +9,6 @@ import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
 main = do
   args <- getArgs
   output_file <- getEnv "HIE_BIOS_OUTPUT"
-  ghcPath <- getEnv "HIE_BIOS_GHC"
-  ghcPathArgs <- fmap (maybe [] words) (lookupEnv "HIE_BIOS_GHC_ARGS")
   case args of
     "--interactive":_ -> do
       h <- openFile output_file AppendMode
@@ -18,6 +16,6 @@ main = do
       mapM_ (hPutStrLn h) args
       hClose h
     _ -> do
-      ph <- spawnProcess ghcPath (ghcPathArgs ++ args)
+      ph <- spawnProcess "ghc" (args)
       code <- waitForProcess ph
       exitWith code


### PR DESCRIPTION
Simplify the code, remove unused code-paths.

closes #152 
Nobody commented on this issue that these environment variables are currently used by anyone, the "feature" is undocumented and we dont use it in hie-bios at all. It just complicates the code.
Moreover, the intention of this "feature" was to fix a problem that was caused by something else, thus, delete them.