### PR TITLE
Store dependencies in CradleError

### DIFF
--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -80,7 +80,7 @@ main = flip E.catches handlers $ do
         res <- forM remainingArgs $ \fp -> do
                 res <- getCompilerOptions fp cradle
                 case res of
-                    CradleFail (CradleError _ex err) ->
+                    CradleFail (CradleError _deps _ex err) ->
                       return $ "Failed to show flags for \""
                                                 ++ fp
                                                 ++ "\": " ++ show err

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -183,6 +183,7 @@ test-suite bios-tests
       extra,
       tasty,
       tasty-hunit,
+      hspec-expectations,
       hie-bios,
       filepath,
       directory,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -52,6 +52,17 @@ Extra-Source-Files:     ChangeLog
                         tests/projects/multi-stack/hie.yaml
                         tests/projects/multi-stack/multi-stack.cabal
                         tests/projects/multi-stack/src/Lib.hs
+                        tests/projects/failing-bios/A.hs
+                        tests/projects/failing-bios/B.cabal
+                        tests/projects/failing-bios/hie.yaml
+                        tests/projects/failing-cabal/failing-cabal.cabal
+                        tests/projects/failing-cabal/hie.yaml
+                        tests/projects/failing-cabal/MyLib.hs
+                        tests/projects/failing-cabal/Setup.hs
+                        tests/projects/failing-stack/failing-stack.cabal
+                        tests/projects/failing-stack/hie.yaml
+                        tests/projects/failing-stack/src/Lib.hs
+                        tests/projects/failing-stack/Setup.hs
                         tests/projects/simple-bios/A.hs
                         tests/projects/simple-bios/B.hs
                         tests/projects/simple-bios/hie-bios.sh
@@ -183,6 +194,7 @@ test-suite bios-tests
       extra,
       tasty,
       tasty-hunit,
+      tasty-expected-failure,
       hspec-expectations,
       hie-bios,
       filepath,

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -283,7 +283,7 @@ multiAction buildCustomCradle cur_dir cs l cur_fp =
         <$> mapM (\(p, c) -> (,c) <$> (canonicalizePath (cur_dir </> p))) cs
 
     selectCradle [] =
-      return (CradleFail (CradleError ExitSuccess err_msg))
+      return (CradleFail (CradleError [] ExitSuccess err_msg))
     selectCradle ((p, c): css) =
         if p `isPrefixOf` cur_fp
           then runCradle
@@ -441,7 +441,7 @@ cabalAction work_dir mc l fp = do
       readProcessWithOutputFile l work_dir (proc "cabal" cab_args)
     deps <- cabalCradleDependencies work_dir
     case processCabalWrapperArgs args of
-        Nothing -> pure $ CradleFail (CradleError ex
+        Nothing -> pure $ CradleFail (CradleError deps ex
                     ["Failed to parse result of calling cabal"
                      , unlines output
                      , unlines stde
@@ -510,7 +510,7 @@ stackAction work_dir mc l _fp = do
         pkg_ghc_args = concatMap (\p -> ["-package-db", p] ) split_pkgs
     deps <- stackCradleDependencies work_dir
     return $ case processCabalWrapperArgs args of
-        Nothing -> CradleFail (CradleError ex1 $
+        Nothing -> CradleFail (CradleError deps ex1 $
                     ("Failed to parse result of calling stack":
                       stde)
                      ++ args)
@@ -684,7 +684,7 @@ readProcessWithOutputFile l work_dir cp = do
 makeCradleResult :: (ExitCode, [String], FilePath, [String]) -> [FilePath] -> CradleLoadResult ComponentOptions
 makeCradleResult (ex, err, componentDir, gopts) deps =
   case ex of
-    ExitFailure _ -> CradleFail (CradleError ex err)
+    ExitFailure _ -> CradleFail (CradleError deps ex err)
     _ ->
         let compOpts = ComponentOptions gopts componentDir deps
         in CradleSuccess compOpts

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -46,8 +46,9 @@ debugInfo fp cradle = unlines <$> do
           , "Cradle:              " ++ crdl
           , "Dependencies:        " ++ unwords deps
           ]
-      CradleFail (CradleError ext stderr) ->
+      CradleFail (CradleError deps ext stderr) ->
         return ["Cradle failed to load"
+               , "Deps: " ++ show deps
                , "Exit Code: " ++ show ext
                , "Stderr: " ++ unlines stderr]
       CradleNone ->

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -73,7 +73,7 @@ data CradleLoadResult r
   deriving (Functor, Show)
 
 
-data CradleError = CradleError ExitCode [String] deriving (Show)
+data CradleError = CradleError [FilePath] ExitCode [String] deriving (Show)
 
 instance Exception CradleError where
 ----------------------------------------------------------------
@@ -81,8 +81,8 @@ instance Exception CradleError where
 -- | Option information for GHC
 data ComponentOptions = ComponentOptions {
     componentOptions  :: [String]  -- ^ Command line options.
-  , componentRoot :: FilePath 
-  -- ^ Root directory of the component. All 'componentOptions' are either 
+  , componentRoot :: FilePath
+  -- ^ Root directory of the component. All 'componentOptions' are either
   -- absolute, or relative to this directory.
   , componentDependencies :: [FilePath]
   -- ^ Dependencies of a cradle that might change the cradle.

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -73,7 +73,17 @@ data CradleLoadResult r
   deriving (Functor, Show)
 
 
-data CradleError = CradleError [FilePath] ExitCode [String] deriving (Show)
+data CradleError = CradleError
+  { cradleErrorDependencies :: [FilePath]
+  -- ^ Dependencies of the cradle that failed to load.
+  -- Can be watched for changes to attempt a reload of the cradle.
+  , cradleErrorExitCode :: ExitCode
+  -- ^ ExitCode of the cradle loading mechanism.
+  , cradleErrorStderr :: [String]
+  -- ^ Standard error output that can be shown to users to explain
+  -- the loading error.
+  }
+  deriving (Show, Eq)
 
 instance Exception CradleError where
 ----------------------------------------------------------------

--- a/tests/projects/failing-bios/A.hs
+++ b/tests/projects/failing-bios/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/tests/projects/failing-bios/B.hs
+++ b/tests/projects/failing-bios/B.hs
@@ -1,0 +1,3 @@
+module B where
+
+import A

--- a/tests/projects/failing-bios/hie.yaml
+++ b/tests/projects/failing-bios/hie.yaml
@@ -1,0 +1,5 @@
+cradle:
+  bios:
+    shell: "exit 1"
+dependencies:
+- hie.yaml

--- a/tests/projects/failing-cabal/MyLib.hs
+++ b/tests/projects/failing-cabal/MyLib.hs
@@ -1,0 +1,4 @@
+module MyLib (someFunc) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"

--- a/tests/projects/failing-cabal/Setup.hs
+++ b/tests/projects/failing-cabal/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tests/projects/failing-cabal/failing-cabal.cabal
+++ b/tests/projects/failing-cabal/failing-cabal.cabal
@@ -1,0 +1,13 @@
+cabal-version:       >=1.10
+name:                failing-cabal
+version:             0.1.0.0
+license-file:        LICENSE
+author:              fendor
+build-type:          Simple
+
+library
+  exposed-modules:     MyLib
+  build-depends:       base >=4.13 && <4.14,
+                       containers < 1 && > 1
+                       --         ^^^^^^^^^^ <<< Invalid constraint
+  default-language:    Haskell2010

--- a/tests/projects/failing-cabal/hie.yaml
+++ b/tests/projects/failing-cabal/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/tests/projects/failing-stack/Setup.hs
+++ b/tests/projects/failing-stack/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/tests/projects/failing-stack/failing-stack.cabal
+++ b/tests/projects/failing-stack/failing-stack.cabal
@@ -1,0 +1,16 @@
+cabal-version: 1.12
+name:           failing-stack
+version:        0.1.0.0
+description:    None
+build-type:     Simple
+
+library
+  exposed-modules:
+      Lib
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5,
+      containes < 1 && > 1
+      --         ^^^^^^^^^^ <<< Invalid constraint
+  default-language: Haskell2010

--- a/tests/projects/failing-stack/hie.yaml
+++ b/tests/projects/failing-stack/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  stack:

--- a/tests/projects/failing-stack/src/Lib.hs
+++ b/tests/projects/failing-stack/src/Lib.hs
@@ -1,0 +1,6 @@
+module Lib
+    ( someFunc
+    ) where
+
+someFunc :: IO ()
+someFunc = putStrLn "someFunc"


### PR DESCRIPTION
This allows you to attempt to rerun a failed cradle if any of the
dependencies change. It is not a very precise measure of why a cradle
failed but better than nothing.

Situations where this helps:

* You have a malformed `hie.yaml`
* You have a missing dependency in your cabal file
* You have a missing prefix in your hie.yaml
* You are missing a target in your cabal file

Situations where it doesn't help:

* A specific module in a dependency doesn't compile. 