### PR TITLE
Export Cradle utilizes

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -15,6 +15,9 @@ module HIE.Bios.Cradle (
     , isMultiCradle
     , isDefaultCradle
     , isOtherCradle
+    , getCradle
+    , readProcessWithOutputFile
+    , makeCradleResult
   ) where
 
 import Control.Exception (handleJust)


### PR DESCRIPTION
Followup to  #178.
closes: #165

This is needed for [Avi-D-coder/implicit-hie-cradle](https://github.com/Avi-D-coder/implicit-hie-cradle).

I copied anything I did not see beaning used by other cradles besides the implicit one.