### PR TITLE
Make path to main-is module absolute

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -53,7 +53,7 @@ Extra-Source-Files:     ChangeLog
                         tests/projects/multi-stack/multi-stack.cabal
                         tests/projects/multi-stack/src/Lib.hs
                         tests/projects/failing-bios/A.hs
-                        tests/projects/failing-bios/B.cabal
+                        tests/projects/failing-bios/B.hs
                         tests/projects/failing-bios/hie.yaml
                         tests/projects/failing-cabal/failing-cabal.cabal
                         tests/projects/failing-cabal/hie.yaml

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -70,5 +70,5 @@ allWarningFlags = unsafePerformIO $ do
     mlibdir <- getSystemLibDir
     G.runGhcT mlibdir $ do
         df <- G.getSessionDynFlags
-        (df', _) <- addCmdOpts ["-Wall"] df
+        (df', _) <- addCmdOpts ["-Wall"] "" df
         return $ G.warningFlags df'


### PR DESCRIPTION
Cabal generates flags for executable and test components passing main-is
module as a relative path, therefore cradles with packages in subdirs
will fail to load those components.

So it has to be made absolute.

Fixes #200.