### PR TITLE
Add getRuntimeGhcLibDir and getRuntimeGhcVersion, via runGhc

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,44 @@
+name: Build and Test
+
+on: [push, pull_request]
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ['8.10.1', '8.8.3', '8.6.5', '8.4.4']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            ghc: '8.8.3' # fails due to segfault
+          - os: macOS-latest
+            ghc: '8.4.4' # fails due to ghc panic
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1.1.1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: '3.2'
+        enable-stack: true
+
+    - name: Cache Cabal
+      uses: actions/cache@v1.2.0
+      with:
+        path: ~/.cabal
+        key: ${{ runner.OS }}-${{ matrix.ghc }}-cabal-0
+
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      if: matrix.os == 'ubuntu-latest'
+      with:
+        ignore: tests
+
+    - run: cabal update
+    - name: Build
+      run: cabal build
+    - name: Test
+      run: cabal test

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -144,7 +144,6 @@ Library
                         extra                >= 1.6.14 && < 1.8,
                         process              >= 1.6.1 && < 1.7,
                         ghc                  >= 8.4.1 && < 8.11,
-                        ghc-paths            >= 0.1 && < 0.2,
                         transformers         >= 0.5.2 && < 0.6,
                         temporary            >= 1.2 && < 1.4,
                         text                 >= 1.2.3 && < 1.3,

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -144,6 +144,7 @@ Library
                         extra                >= 1.6.14 && < 1.8,
                         process              >= 1.6.1 && < 1.7,
                         ghc                  >= 8.4.1 && < 8.11,
+                        ghc-paths            >= 0.1 && < 0.2,
                         transformers         >= 0.5.2 && < 0.6,
                         temporary            >= 1.2 && < 1.4,
                         text                 >= 1.2.3 && < 1.3,

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -215,7 +215,7 @@ defaultCradle cur_dir =
         { actionName = Types.Default
         , runCradle = \_ _ ->
             return (CradleSuccess (ComponentOptions [] cur_dir []))
-        , runGhc = runGhcOnPath cur_dir
+        , runGhcCmd = runGhcCmdOnPath cur_dir
         }
     }
 
@@ -229,7 +229,7 @@ noneCradle cur_dir =
     , cradleOptsProg = CradleAction
         { actionName = Types.None
         , runCradle = \_ _ -> return CradleNone
-        , runGhc = const $ pure Nothing
+        , runGhcCmd = const $ pure Nothing
         }
     }
 
@@ -243,13 +243,13 @@ multiCradle buildCustomCradle cur_dir cs =
     , cradleOptsProg = CradleAction
         { actionName = multiActionName
         , runCradle  = \l fp -> canonicalizePath fp >>= multiAction buildCustomCradle cur_dir cs l
-        , runGhc = \args ->
+        , runGhcCmd = \args ->
             -- We're being lazy here and just returning the ghc path for the
             -- first non-none cradle. This shouldn't matter in practice: all
             -- sub cradles should be using the same ghc version!
             case filter (not . isNoneCradleConfig) $ map snd cs of
               [] -> return Nothing
-              (cfg:_) -> flip runGhc args $ cradleOptsProg $
+              (cfg:_) -> flip runGhcCmd args $ cradleOptsProg $
                 getCradle buildCustomCradle (cfg, cur_dir)
         }
     }
@@ -324,7 +324,7 @@ directCradle wdir args =
         { actionName = Types.Direct
         , runCradle = \_ _ ->
             return (CradleSuccess (ComponentOptions args wdir []))
-        , runGhc = runGhcOnPath wdir
+        , runGhcCmd = runGhcCmdOnPath wdir
         }
     }
 
@@ -340,7 +340,7 @@ biosCradle wdir biosCall biosDepsCall =
     , cradleOptsProg   = CradleAction
         { actionName = Types.Bios
         , runCradle = biosAction wdir biosCall biosDepsCall
-        , runGhc = runGhcOnPath wdir
+        , runGhcCmd = runGhcCmdOnPath wdir
         }
     }
 
@@ -392,7 +392,7 @@ cabalCradle wdir mc =
     , cradleOptsProg   = CradleAction
         { actionName = Types.Cabal
         , runCradle = cabalAction wdir mc
-        , runGhc = \args -> optional $ do
+        , runGhcCmd = \args -> optional $ do
             -- Workaround for a cabal-install bug on 3.0.0.0:
             -- ./dist-newstyle/tmp/environment.-24811: createDirectory: does not exist (No such file or directory)
             -- (It's ok to pass 'dist-newstyle' here, as it can only be changed
@@ -539,7 +539,7 @@ stackCradle wdir mc =
     , cradleOptsProg   = CradleAction
         { actionName = Types.Stack
         , runCradle = stackAction wdir mc
-        , runGhc = \args -> optional $
+        , runGhcCmd = \args -> optional $
             readProcessWithCwd
               wdir "stack" (["exec", "--silent", "ghc", "--"] <> args) ""
         }
@@ -746,8 +746,8 @@ makeCradleResult (ex, err, componentDir, gopts) deps =
         in CradleSuccess compOpts
 
 -- | Calls @ghc --print-libdir@, with just whatever's on the PATH.
-runGhcOnPath :: FilePath -> [String] -> IO (Maybe String)
-runGhcOnPath wdir args = optional $ readProcessWithCwd wdir "ghc" args ""
+runGhcCmdOnPath :: FilePath -> [String] -> IO (Maybe String)
+runGhcCmdOnPath wdir args = optional $ readProcessWithCwd wdir "ghc" args ""
 
 -- | Wrapper around 'readCreateProcess' that sets the working directory
 readProcessWithCwd :: FilePath -> FilePath -> [String] -> String -> IO String

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -55,7 +55,7 @@ initSession  ComponentOptions {..} = do
 ----------------------------------------------------------------
 
 -- | @getRuntimeGhcLibDir cradle@ will give you the ghc libDir:
--- __do not__ use 'runGhcLibDir' directly.
+-- __do not__ use 'runGhcCmd' directly.
 -- This will also perform additional lookups and fallbacks to try and get a
 -- reliable library directory.
 -- It tries this specific order of paths:
@@ -68,7 +68,7 @@ getRuntimeGhcLibDir cradle = runMaybeT $ fromNix <|> fromCradle
   where
     fromNix = MaybeT $ lookupEnv "NIX_GHC_LIBDIR"
     fromCradle = MaybeT $ fmap (fmap trim) $
-      runGhc (cradleOptsProg cradle) ["--print-libdir"]
+      runGhcCmd (cradleOptsProg cradle) ["--print-libdir"]
 
 -- | Gets the version of ghc used when compiling the cradle. It is based off of
 -- 'getRuntimeGhcLibDir'. If it can't work out the verison reliably, it will
@@ -77,7 +77,7 @@ getRuntimeGhcVersion :: Cradle a
                      -> IO String
 getRuntimeGhcVersion cradle =
   fmap (fromMaybe VERSION_ghc) $ fmap (fmap trim) $
-    runGhc (cradleOptsProg cradle) ["--numeric-version"]
+    runGhcCmd (cradleOptsProg cradle) ["--numeric-version"]
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -6,6 +6,7 @@ module HIE.Bios.Ghc.Check (
 import GHC (DynFlags(..), GhcMonad)
 import Exception
 
+import HIE.Bios.Environment
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Logger
 import qualified HIE.Bios.Internal.Log as Log
@@ -16,6 +17,7 @@ import Control.Monad.IO.Class
 import System.IO.Unsafe (unsafePerformIO)
 import qualified HIE.Bios.Ghc.Gap as Gap
 
+import qualified DynFlags as G
 import qualified GHC as G
 import HIE.Bios.Environment
 
@@ -28,15 +30,17 @@ checkSyntax :: Show a
             -> [FilePath]  -- ^ The target files.
             -> IO String
 checkSyntax _      []    = return ""
-checkSyntax cradle files = withGhcT $ do
-    Log.debugm $ "Cradle: " ++ show cradle
-    res <- initializeFlagsWithCradle (head files) cradle
-    case res of
-      CradleSuccess (ini, _) -> do
-        _sf <- ini
-        either id id <$> check files
-      CradleFail ce -> liftIO $ throwIO ce
-      CradleNone -> return "No cradle"
+checkSyntax cradle files = do
+    libDir <- getRuntimeGhcLibDir cradle False
+    G.runGhcT libDir $ do
+      Log.debugm $ "Cradle: " ++ show cradle
+      res <- initializeFlagsWithCradle (head files) cradle
+      case res of
+        CradleSuccess (ini, _) -> do
+          _sf <- ini
+          either id id <$> check files
+        CradleFail ce -> liftIO $ throwIO ce
+        CradleNone -> return "No cradle"
 
 
   where
@@ -53,7 +57,9 @@ checkSyntax cradle files = withGhcT $ do
 check :: (GhcMonad m)
       => [FilePath]  -- ^ The target files.
       -> m (Either String String)
-check fileNames = withLogger setAllWarningFlags $ setTargetFiles (map dup fileNames)
+check fileNames = do
+  libDir <- G.topDir <$> G.getDynFlags
+  withLogger (setAllWarningFlags libDir) $ setTargetFiles (map dup fileNames)
 
 dup :: a -> (a, a)
 dup x = (x, x)
@@ -61,14 +67,13 @@ dup x = (x, x)
 ----------------------------------------------------------------
 
 -- | Set 'DynFlags' equivalent to "-Wall".
-setAllWarningFlags :: DynFlags -> DynFlags
-setAllWarningFlags df = df { warningFlags = allWarningFlags }
+setAllWarningFlags :: FilePath -> DynFlags -> DynFlags
+setAllWarningFlags libDir df = df { warningFlags = allWarningFlags libDir }
 
 {-# NOINLINE allWarningFlags #-}
-allWarningFlags :: Gap.WarnFlags
-allWarningFlags = unsafePerformIO $ do
-    mlibdir <- getSystemLibDir
-    G.runGhcT mlibdir $ do
+allWarningFlags :: FilePath -> Gap.WarnFlags
+allWarningFlags libDir = unsafePerformIO $
+    G.runGhcT (Just libDir) $ do
         df <- G.getSessionDynFlags
         (df', _) <- addCmdOpts ["-Wall"] df
         return $ G.warningFlags df'

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -30,7 +30,7 @@ checkSyntax :: Show a
             -> IO String
 checkSyntax _      []    = return ""
 checkSyntax cradle files = do
-    libDir <- getRuntimeGhcLibDir cradle False
+    libDir <- getRuntimeGhcLibDir cradle
     G.runGhcT libDir $ do
       Log.debugm $ "Cradle: " ++ show cradle
       res <- initializeFlagsWithCradle (head files) cradle

--- a/src/HIE/Bios/Ghc/Check.hs
+++ b/src/HIE/Bios/Ghc/Check.hs
@@ -19,7 +19,6 @@ import qualified HIE.Bios.Ghc.Gap as Gap
 
 import qualified DynFlags as G
 import qualified GHC as G
-import HIE.Bios.Environment
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Ghc/Logger.hs
+++ b/src/HIE/Bios/Ghc/Logger.hs
@@ -10,7 +10,7 @@ import DynFlags (LogAction, dopt, DumpFlag(Opt_D_dump_splices))
 import ErrUtils
 import Exception (ghandle)
 import FastString (unpackFS)
-import GHC (DynFlags(..), SrcSpan(..), Severity(SevError), GhcMonad)
+import GHC (DynFlags(..), SrcSpan(..), GhcMonad)
 import qualified GHC as G
 import HscTypes (SourceError, srcErrorMessages)
 import Outputable (PprStyle, SDoc)

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE LambdaCase #-}
 module HIE.Bios.Internal.Debug (debugInfo, rootInfo, configInfo, cradleInfo) where
 
-import Control.Monad.IO.Class (liftIO)
 import Control.Monad
 import Data.Void
 
 import qualified Data.Char as Char
-import Data.Maybe (fromMaybe)
 
-import HIE.Bios.Ghc.Api
 import HIE.Bios.Cradle
+import HIE.Bios.Environment
 import HIE.Bios.Types
 import HIE.Bios.Flags
 
@@ -34,17 +32,17 @@ debugInfo fp cradle = unlines <$> do
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
     crdl <- findCradle' canonFp
+    ghcLibDir <- getRuntimeGhcLibDir cradle False
     case res of
       CradleSuccess (ComponentOptions gopts croot deps) -> do
-        mglibdir <- liftIO getSystemLibDir
         return [
-            "Root directory:      " ++ rootDir
-          , "Component directory: " ++ croot
-          , "GHC options:         " ++ unwords (map quoteIfNeeded gopts)
-          , "System libraries:    " ++ fromMaybe "" mglibdir
-          , "Config Location:     " ++ conf
-          , "Cradle:              " ++ crdl
-          , "Dependencies:        " ++ unwords deps
+            "Root directory:        " ++ rootDir
+          , "Component directory:   " ++ croot
+          , "GHC options:           " ++ unwords (map quoteIfNeeded gopts)
+          , "GHC library directory: " ++ show ghcLibDir
+          , "Config Location:       " ++ conf
+          , "Cradle:                " ++ crdl
+          , "Dependencies:          " ++ unwords deps
           ]
       CradleFail (CradleError deps ext stderr) ->
         return ["Cradle failed to load"

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -33,6 +33,7 @@ debugInfo fp cradle = unlines <$> do
     conf <- findConfig canonFp
     crdl <- findCradle' canonFp
     ghcLibDir <- getRuntimeGhcLibDir cradle False
+    ghcVer <- getRuntimeGhcVersion cradle
     case res of
       CradleSuccess (ComponentOptions gopts croot deps) -> do
         return [
@@ -40,6 +41,7 @@ debugInfo fp cradle = unlines <$> do
           , "Component directory:   " ++ croot
           , "GHC options:           " ++ unwords (map quoteIfNeeded gopts)
           , "GHC library directory: " ++ show ghcLibDir
+          , "GHC version:           " ++ show ghcVer
           , "Config Location:       " ++ conf
           , "Cradle:                " ++ crdl
           , "Dependencies:          " ++ unwords deps

--- a/src/HIE/Bios/Internal/Debug.hs
+++ b/src/HIE/Bios/Internal/Debug.hs
@@ -32,7 +32,7 @@ debugInfo fp cradle = unlines <$> do
     canonFp <- canonicalizePath fp
     conf <- findConfig canonFp
     crdl <- findCradle' canonFp
-    ghcLibDir <- getRuntimeGhcLibDir cradle False
+    ghcLibDir <- getRuntimeGhcLibDir cradle
     ghcVer <- getRuntimeGhcVersion cradle
     case res of
       CradleSuccess (ComponentOptions gopts croot deps) -> do

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -58,6 +58,9 @@ data CradleAction a = CradleAction {
                       , runCradle     :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
                       , runGhc :: [String] -> IO (Maybe String)
+                      -- ^ Executes the @ghc@ binary that is usually used to
+                      -- build the cradle. E.g. for a cabal cradle this should be
+                      -- equivalent to @cabal exec ghc -- args@
                       }
   deriving (Functor)
 

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -57,7 +57,7 @@ data CradleAction a = CradleAction {
                       -- ^ Name of the action.
                       , runCradle     :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
-                      , runGhc :: [String] -> IO (Maybe String)
+                      , runGhcCmd :: [String] -> IO (Maybe String)
                       -- ^ Executes the @ghc@ binary that is usually used to
                       -- build the cradle. E.g. for a cabal cradle this should be
                       -- equivalent to @cabal exec ghc -- args@

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -53,10 +53,14 @@ data ActionName a
   deriving (Show, Eq, Ord, Functor)
 
 data CradleAction a = CradleAction {
-                      actionName :: ActionName a
+                        actionName   :: ActionName a
                       -- ^ Name of the action.
-                      , runCradle :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
+                      , runCradle    :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
+                      , runGhcLibDir :: IO (Maybe FilePath)
+                      -- ^ Try to find the path to /the libdir/ of the GHC that
+                      -- this cradle uses to compile stuff normally. You don't
+                      -- want to call this directly, use 'getGhcLibDir' instead.
                       }
   deriving (Functor)
 

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -53,14 +53,11 @@ data ActionName a
   deriving (Show, Eq, Ord, Functor)
 
 data CradleAction a = CradleAction {
-                        actionName   :: ActionName a
+                        actionName    :: ActionName a
                       -- ^ Name of the action.
-                      , runCradle    :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
+                      , runCradle     :: LoggingFunction -> FilePath -> IO (CradleLoadResult ComponentOptions)
                       -- ^ Options to compile the given file with.
-                      , runGhcLibDir :: IO (Maybe FilePath)
-                      -- ^ Try to find the path to /the libdir/ of the GHC that
-                      -- this cradle uses to compile stuff normally. You don't
-                      -- want to call this directly, use 'getGhcLibDir' instead.
+                      , runGhc :: [String] -> IO (Maybe String)
                       }
   deriving (Functor)
 

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -116,7 +116,7 @@ testDirectory cradlePred fp step = do
 -- always works.
 testGetGhcLibDir :: Cradle a -> IO ()
 testGetGhcLibDir crd =
-  getRuntimeGhcLibDir crd True `shouldNotReturn` Nothing
+  getRuntimeGhcLibDir crd `shouldNotReturn` Nothing
 
 -- | Here we are testing that the cradle's method of getting the runtime ghc
 -- version is correct - which while testing, should be the version that we have
@@ -147,7 +147,7 @@ initialiseCradle cradlePred a_fp step = do
 testLoadFile :: Cradle a -> FilePath -> (String -> IO ()) -> IO ()
 testLoadFile crd fp step = do
   a_fp <- canonicalizePath fp
-  libDir <- getRuntimeGhcLibDir crd False
+  libDir <- getRuntimeGhcLibDir crd
   withCurrentDirectory (cradleRootDir crd) $
     G.runGhc libDir $ do
       let relFp = makeRelative (cradleRootDir crd) a_fp
@@ -166,7 +166,7 @@ testLoadFile crd fp step = do
 testLoadFileCradleFail :: Cradle a -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
 testLoadFileCradleFail crd fp cradleErrorExpectation step = do
   a_fp <- canonicalizePath fp
-  libDir <- getRuntimeGhcLibDir crd False
+  libDir <- getRuntimeGhcLibDir crd
   withCurrentDirectory (cradleRootDir crd) $
     G.runGhc libDir $ do
       let relFp = makeRelative (cradleRootDir crd) a_fp

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -4,13 +4,17 @@
 module Main where
 
 import Test.Tasty
-import Test.Tasty.ExpectedFailure
 import Test.Tasty.HUnit
 import Test.Hspec.Expectations
+#if __GLASGOW_HASKELL__ < 810
+import Test.Tasty.ExpectedFailure
+#endif
+import qualified GHC as G
 import HIE.Bios
 import HIE.Bios.Ghc.Api
 import HIE.Bios.Ghc.Load
 import HIE.Bios.Cradle
+import HIE.Bios.Environment
 import HIE.Bios.Types
 import Control.Monad.IO.Class
 import Control.Monad ( forM_ )
@@ -100,8 +104,16 @@ testDirectory :: (Cradle Void -> Bool) -> FilePath -> (String -> IO ()) -> IO ()
 testDirectory cradlePred fp step = do
   a_fp <- canonicalizePath fp
   crd <- initialiseCradle cradlePred a_fp step
+  step "Get GHC library directory"
+  testGetGhcLibDir crd
   step "Initialise Flags"
   testLoadFile crd a_fp step
+
+-- Here we are testing that the cradle's method of obtaining the ghcLibDir
+-- always works.
+testGetGhcLibDir :: Cradle a -> IO ()
+testGetGhcLibDir crd =
+  runGhcLibDir (cradleOptsProg crd) `shouldNotReturn` Nothing
 
 testDirectoryFail :: (Cradle Void -> Bool) -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
 testDirectoryFail cradlePred fp cradleFailPred step = do
@@ -124,8 +136,9 @@ initialiseCradle cradlePred a_fp step = do
 testLoadFile :: Cradle a -> FilePath -> (String -> IO ()) -> IO ()
 testLoadFile crd fp step = do
   a_fp <- canonicalizePath fp
+  libDir <- getRuntimeGhcLibDir crd False
   withCurrentDirectory (cradleRootDir crd) $
-    withGHC' $ do
+    G.runGhc libDir $ do
       let relFp = makeRelative (cradleRootDir crd) a_fp
       res <- initializeFlagsWithCradleWithMessage (Just (\_ n _ _ -> step (show n))) relFp crd
       case res of
@@ -142,8 +155,9 @@ testLoadFile crd fp step = do
 testLoadFileCradleFail :: Cradle a -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
 testLoadFileCradleFail crd fp cradleErrorExpectation step = do
   a_fp <- canonicalizePath fp
+  libDir <- getRuntimeGhcLibDir crd False
   withCurrentDirectory (cradleRootDir crd) $
-    withGHC' $ do
+    G.runGhc libDir $ do
       let relFp = makeRelative (cradleRootDir crd) a_fp
       res <- initializeFlagsWithCradleWithMessage (Just (\_ n _ _ -> step (show n))) relFp crd
       case res of


### PR DESCRIPTION
This PR moves the logic in ghcide/hls of getting the **runtime** ghc library directory and version into hie-bios, and in doing so moves the responsibility to the cradle