### PR TITLE
Prepare release 0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@
 #
 # version: 0.3
 #
+# Additional changes included a shellcheck step
 language: c
 dist: xenial
 
@@ -86,6 +87,10 @@ install:
 # Here starts the actual work to be performed for the package under test;
 # any command which exits with a non-zero exit code causes the build to fail.
 script:
+  # Sanity checks for wrapper scripts
+  - shellcheck wrappers/cabal
+  - (cd wrappers && ${HC} -hide-all-packages -package base -package directory -package process -Wall -Werror cabal.hs -o CabalWrapper -hidir ${TMPDIR} -odir ${TMPDIR})
+
   # test that source-distributions can be generated
   - ${CABAL} new-sdist all
   - mv dist-newstyle/sdist/*.tar.gz ${DISTDIR}/
@@ -114,6 +119,3 @@ script:
 
   # Build without installed constraints for packages in global-db
   - rm -f cabal.project.local; ${CABAL} new-build -w ${HC} --disable-tests --disable-benchmarks all
-
-# REGENDATA ["hie-bios.cabal"]
-# EOF

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2020-06-26 - 0.5.1
+
+	* Fix printing of current directory in wrapper script [#206](https://github.com/mpickering/hie-bios/pull/206)
+	* Export Cradle utilizes [#189](https://github.com/mpickering/hie-bios/pull/189)
+
 2020-05-08 - 0.5.0
 
 	* Add cabal.project.local to cabal cradle dependencies [#184](https://github.com/mpickering/hie-bios/pull/184)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,10 @@ install:
   - choco install -y haskell-stack
   - choco install -y cabal
   - choco install ghc --version %GHCVER%
+  - choco install -y shellcheck
   - refreshenv
   - "set PATH=C:\\ProgramData\\chocolatey\\lib\\ghc\\tools\\ghc-%GHCVER%\\bin;C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin;%PATH%"
+  - shellcheck --version
   - stack --version
   - cabal --version
   - ghc --version
@@ -30,6 +32,10 @@ build_script:
 
 before_test:
   - cabal v2-build --enable-tests -w ghc-%GHCVER%.exe tests
+  # sanity check the wrappers
+  - shellcheck wrappers/cabal
+  - ghc -hide-all-packages -package base -package directory -package process -Wall -Werror wrappers/cabal.hs -o CabalWrapper -hidir %TMP% -odir %TMP%
+
 
 test_script:
   - cabal v2-test -w ghc-%GHCVER%.exe

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   hie-bios
-Version:                0.5.0
+Version:                0.5.1
 Author:                 Matthew Pickering <matthewtpickering@gmail.com>
 Maintainer:             Matthew Pickering <matthewtpickering@gmail.com>
 License:                BSD-3-Clause

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -15,6 +15,9 @@ module HIE.Bios.Cradle (
     , isMultiCradle
     , isDefaultCradle
     , isOtherCradle
+    , getCradle
+    , readProcessWithOutputFile
+    , makeCradleResult
   ) where
 
 import Control.Exception (handleJust)

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -5,7 +5,7 @@ function out(){
 }
 
 if [ "$1" == "--interactive" ]; then
-  out $(pwd)
+  out "$(pwd)"
   for arg in "$@"; do
     out "$arg"
   done

--- a/wrappers/cabal
+++ b/wrappers/cabal
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function out(){
-  echo "$1" >> $HIE_BIOS_OUTPUT
+  echo "$1" >> "$HIE_BIOS_OUTPUT"
 }
 
 if [ "$1" == "--interactive" ]; then

--- a/wrappers/cabal.hs
+++ b/wrappers/cabal.hs
@@ -1,11 +1,12 @@
 module Main (main) where
 
 import System.Directory (getCurrentDirectory)
-import System.Environment (getArgs, getEnv, lookupEnv)
+import System.Environment (getArgs, getEnv)
 import System.Exit (exitWith)
 import System.Process (spawnProcess, waitForProcess)
 import System.IO (openFile, hClose, hPutStrLn, IOMode(..))
 
+main :: IO ()
 main = do
   args <- getArgs
   output_file <- getEnv "HIE_BIOS_OUTPUT"


### PR DESCRIPTION
This PR should not be merged.
It contains only a single bug fix (b09b1fe54d901e3e6469bd4d190f7bc3191e1af1) and adds an export: (f14524f3415018c643778e5691b6e6fcd4c1f1fa)

When CI is green, this PR is pushed into the main repo, tagged as a release and then the ChangeLog and hie-bios.cabal changes will be cherry-picked on master. 
This way we dont have any breaking changes but include the important bug-fix.

cc @Avi-D-coder 