### PR TITLE
Detect implicit cabal cradle in the absence of cabal.project

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,7 +32,7 @@ jobs:
         key: ${{ runner.OS }}-${{ matrix.ghc }}-cabal-0
 
     - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@2f2aa0d
       if: matrix.os == 'ubuntu-latest'
       with:
         ignore: tests

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -119,6 +119,14 @@ Extra-Source-Files:     ChangeLog
                         tests/projects/implicit-cabal/cabal.project
                         tests/projects/implicit-cabal/implicit-cabal.cabal
                         tests/projects/implicit-cabal/Main.hs
+                        tests/projects/implicit-cabal-no-project/implicit-cabal-no-project.cabal
+                        tests/projects/implicit-cabal-no-project/Main.hs
+                        tests/projects/implicit-cabal-deep-project/README
+                        tests/projects/implicit-cabal-deep-project/implicit-cabal-deep-project.cabal
+                        tests/projects/implicit-cabal-deep-project/Main.hs
+                        tests/projects/implicit-cabal-deep-project/cabal.project
+                        tests/projects/implicit-cabal-deep-project/foo/foo.cabal
+                        tests/projects/implicit-cabal-deep-project/foo/Main.hs
                         tests/projects/implicit-stack/Setup.hs
                         tests/projects/implicit-stack/implicit-stack.cabal
                         tests/projects/implicit-stack/Main.hs
@@ -229,6 +237,7 @@ test-suite bios-tests
       hie-bios,
       filepath,
       directory,
+      temporary,
       ghc
 
   hs-source-dirs: tests/

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -544,9 +544,9 @@ removeVerbosityOpts = filter ((&&) <$> (/= "-v0") <*> (/= "-w"))
 
 
 cabalWorkDir :: FilePath -> MaybeT IO FilePath
-cabalWorkDir = findFileUpwards isCabal
-  where
-    isCabal name = name == "cabal.project"
+cabalWorkDir wdir =
+      findFileUpwards (== "cabal.project") wdir
+  <|> findFileUpwards (\fp -> takeExtension fp == ".cabal") wdir
 
 ------------------------------------------------------------------------
 -- | Stack Cradle

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -57,97 +57,97 @@ main = do
       , testGroup "Loading tests"
         $ linuxExlusiveTestCases
         ++
-           [ testCaseSteps "failing-cabal" $ testDirectoryFail isCabalCradle "./tests/projects/failing-cabal/MyLib.hs"
+           [ testCaseSteps "failing-cabal" $ testDirectoryFail isCabalCradle "./tests/projects/failing-cabal" "MyLib.hs"
               (\CradleError {..} -> do
                   cradleErrorExitCode `shouldBe` ExitFailure 1
                   cradleErrorDependencies `shouldMatchList` ["failing-cabal.cabal", "cabal.project", "cabal.project.local"])
-           , testCaseSteps "failing-bios" $ testDirectoryFail isBiosCradle "./tests/projects/failing-bios/B.hs"
+           , testCaseSteps "failing-bios" $ testDirectoryFail isBiosCradle "./tests/projects/failing-bios" "B.hs"
               (\CradleError {..} -> do
                   cradleErrorExitCode `shouldBe` ExitFailure 1
                   cradleErrorDependencies `shouldMatchList` ["hie.yaml"])
-           , testCaseSteps "simple-bios-shell" $ testDirectory isBiosCradle "./tests/projects/simple-bios-shell/B.hs"
-           , testCaseSteps "simple-cabal" $ testDirectory isCabalCradle "./tests/projects/simple-cabal/B.hs"
-           , testCaseSteps "simple-direct" $ testDirectory isDirectCradle "./tests/projects/simple-direct/B.hs"
-           , testCaseSteps "nested-cabal" $ testLoadCradleDependencies isCabalCradle "./tests/projects/nested-cabal/sub-comp/Lib.hs"
+           , testCaseSteps "simple-bios-shell" $ testDirectory isBiosCradle "./tests/projects/simple-bios-shell" "B.hs"
+           , testCaseSteps "simple-cabal" $ testDirectory isCabalCradle "./tests/projects/simple-cabal" "B.hs"
+           , testCaseSteps "simple-direct" $ testDirectory isDirectCradle "./tests/projects/simple-direct" "B.hs"
+           , testCaseSteps "nested-cabal" $ testLoadCradleDependencies isCabalCradle "./tests/projects/nested-cabal" "sub-comp/Lib.hs"
               (\deps -> deps `shouldMatchList` ["sub-comp" </> "sub-comp.cabal", "cabal.project", "cabal.project.local"]
               )
-           , testCaseSteps "nested-cabal2" $ testLoadCradleDependencies isCabalCradle "./tests/projects/nested-cabal/MyLib.hs"
+           , testCaseSteps "nested-cabal2" $ testLoadCradleDependencies isCabalCradle "./tests/projects/nested-cabal" "MyLib.hs"
               (\deps -> deps `shouldMatchList` ["nested-cabal.cabal", "cabal.project", "cabal.project.local"]
               )
            , testCaseSteps "multi-direct" {- tests if both components can be loaded -}
-                         $  testDirectory isMultiCradle "./tests/projects/multi-direct/A.hs"
-                         >> testDirectory isMultiCradle "./tests/projects/multi-direct/B.hs"
+                         $  testDirectory isMultiCradle "./tests/projects/multi-direct" "A.hs"
+                         >> testDirectory isMultiCradle "./tests/projects/multi-direct" "B.hs"
            , testCaseSteps "multi-cabal" {- tests if both components can be loaded -}
-                         $  testDirectory isCabalCradle "./tests/projects/multi-cabal/app/Main.hs"
-                         >> testDirectory isCabalCradle "./tests/projects/multi-cabal/src/Lib.hs"
+                         $  testDirectory isCabalCradle "./tests/projects/multi-cabal" "app/Main.hs"
+                         >> testDirectory isCabalCradle "./tests/projects/multi-cabal" "src/Lib.hs"
            , testCaseSteps "monorepo-cabal" {- issue https://github.com/mpickering/hie-bios/issues/200 -}
-                         $  testDirectory isCabalCradle "./tests/projects/monorepo-cabal/A/Main.hs"
-                         >> testDirectory isCabalCradle "./tests/projects/monorepo-cabal/B/MyLib.hs"
+                         $  testDirectory isCabalCradle "./tests/projects/monorepo-cabal" "A/Main.hs"
+                         >> testDirectory isCabalCradle "./tests/projects/monorepo-cabal" "B/MyLib.hs"
            ]
 -- TODO: Remove once stack and ghc-8.10.1 play well
 -- https://github.com/bubba/hie-bios/runs/811271872?check_suite_focus=true
 #if __GLASGOW_HASKELL__ < 810
        ++ [ expectFailBecause "stack repl does not fail on an invalid cabal file" $
-              testCaseSteps "failing-stack" $ testDirectoryFail isStackCradle "./tests/projects/failing-stack/src/Lib.hs"
+              testCaseSteps "failing-stack" $ testDirectoryFail isStackCradle "./tests/projects/failing-stack" "src/Lib.hs"
                 (\CradleError {..} -> do
                     cradleErrorExitCode `shouldBe` ExitFailure 1
                     cradleErrorDependencies `shouldMatchList` ["failing-stack.cabal", "stack.yaml", "package.yaml"])
-          , testCaseSteps "simple-stack" $ testDirectory isStackCradle "./tests/projects/simple-stack/B.hs"
+          , testCaseSteps "simple-stack" $ testDirectory isStackCradle "./tests/projects/simple-stack" "B.hs"
           , testCaseSteps "multi-stack" {- tests if both components can be loaded -}
-                        $  testDirectory isStackCradle "./tests/projects/multi-stack/app/Main.hs"
-                        >> testDirectory isStackCradle "./tests/projects/multi-stack/src/Lib.hs"
+                        $  testDirectory isStackCradle "./tests/projects/multi-stack" "app/Main.hs"
+                        >> testDirectory isStackCradle "./tests/projects/multi-stack" "src/Lib.hs"
           , expectFailBecause "stack repl set the component directory to the root directory" $
-              testCaseSteps "nested-stack" $ testLoadCradleDependencies isStackCradle "./tests/projects/nested-stack/sub-comp/Lib.hs"
+              testCaseSteps "nested-stack" $ testLoadCradleDependencies isStackCradle "./tests/projects/nested-stack" "sub-comp/Lib.hs"
                 (\deps -> deps `shouldMatchList`
                   ["sub-comp" </> "sub-comp.cabal", "sub-comp" </> "package.yaml", "stack.yaml"]
                 )
-          , testCaseSteps "nested-stack2" $ testLoadCradleDependencies isStackCradle "./tests/projects/nested-stack/MyLib.hs"
+          , testCaseSteps "nested-stack2" $ testLoadCradleDependencies isStackCradle "./tests/projects/nested-stack" "MyLib.hs"
               (\deps -> deps `shouldMatchList` ["nested-stack.cabal", "package.yaml", "stack.yaml"]
               )
           ,
           -- Test for special characters in the path for parsing of the ghci-scripts.
           -- Issue https://github.com/mpickering/hie-bios/issues/162
           testCaseSteps "space stack"
-                        $  testDirectory isStackCradle "./tests/projects/space stack/A.hs"
-                        >> testDirectory isStackCradle "./tests/projects/space stack/B.hs"
+                        $  testDirectory isStackCradle "./tests/projects/space stack" "A.hs"
+                        >> testDirectory isStackCradle "./tests/projects/space stack" "B.hs"
           ]
 #endif
       , testGroup "Implicit cradle tests" $
         [ testCaseSteps "implicit-cabal" $
-            testImplicitCradle "./tests/projects/implicit-cabal/Main.hs" Cabal "./tests/projects/implicit-cabal"
-        , testCaseSteps "implicit-cabal-no-project" $ \step ->
-            -- Here we NEED to copy this project to a temporary directory
-            -- because when getting the flags, `cabal repl` will always use the cabal.project of
-            -- hie-bios in this source tree, and then complain that Main.hs doesn't exist
-            copyToTmp "./tests/projects/implicit-cabal-no-project" $ \copy ->
-              testImplicitCradle (copy </> "Main.hs") Cabal copy step
+            testImplicitCradle "./tests/projects/implicit-cabal" "Main.hs" Cabal
+        , testCaseSteps "implicit-cabal-no-project" $
+            testImplicitCradle "./tests/projects/implicit-cabal-no-project" "Main.hs" Cabal
         , testCaseSteps "implicit-cabal-deep-project" $
-            testImplicitCradle "./tests/projects/implicit-cabal-deep-project/foo/Main.hs" Cabal "./tests/projects/implicit-cabal-deep-project"
+            testImplicitCradle "./tests/projects/implicit-cabal-deep-project" "foo/Main.hs" Cabal
 -- TODO: same here
 #if __GLASGOW_HASKELL__ < 810
         , testCaseSteps "implicit-stack" $
-            testImplicitCradle "./tests/projects/implicit-stack/Main.hs" Stack "./tests/projects/implicit-stack"
+            testImplicitCradle "./tests/projects/implicit-stack" "Main.hs" Stack
         , testCaseSteps "implicit-stack-multi"
-            $ testImplicitCradle "./tests/projects/implicit-stack-multi/Main.hs" Stack "./tests/projects/implicit-stack-multi"
-            >> testImplicitCradle "./tests/projects/implicit-stack-multi/other-package/Main.hs" Stack "./tests/projects/implicit-stack-multi"
+            $ testImplicitCradle "./tests/projects/implicit-stack-multi" "Main.hs" Stack
+            >> testImplicitCradle "./tests/projects/implicit-stack-multi" "other-package/Main.hs" Stack
 #endif
         ]
       ]
 
 linuxExlusiveTestCases :: [TestTree]
 linuxExlusiveTestCases =
-  [ testCaseSteps "simple-bios" $ testDirectory isBiosCradle "./tests/projects/simple-bios/B.hs" | not isWindows ]
+  [ testCaseSteps "simple-bios" $ testDirectory isBiosCradle "./tests/projects/simple-bios" "B.hs" | not isWindows ]
 
-testDirectory :: (Cradle Void -> Bool) -> FilePath -> (String -> IO ()) -> IO ()
-testDirectory cradlePred fp step = do
-  a_fp <- canonicalizePath fp
-  crd <- initialiseCradle cradlePred a_fp step
-  step "Get runtime GHC library directory"
-  testGetGhcLibDir crd
-  step "Get runtime GHC version"
-  testGetGhcVersion crd
-  step "Initialise Flags"
-  testLoadFile crd a_fp step
+testDirectory :: (Cradle Void -> Bool) -> FilePath -> FilePath -> (String -> IO ()) -> IO ()
+testDirectory cradlePred rootDir file step =
+  -- We need to copy over the directory to somewhere outside the source tree
+  -- when we test, since the cabal.project/stack.yaml/hie.yaml file in the root
+  -- of this repository interferes with the test cradles!
+  withTempCopy rootDir $ \rootDir' -> do
+    fp <- canonicalizePath (rootDir' </> file)
+    crd <- initialiseCradle cradlePred fp step
+    step "Get runtime GHC library directory"
+    testGetGhcLibDir crd
+    step "Get runtime GHC version"
+    testGetGhcVersion crd
+    step "Initialise Flags"
+    testLoadFile crd fp step
 
 -- | Here we are testing that the cradle's method of obtaining the ghcLibDir
 -- always works.
@@ -163,12 +163,13 @@ testGetGhcVersion :: Cradle a -> IO ()
 testGetGhcVersion crd =
   getRuntimeGhcVersion crd `shouldReturn` VERSION_ghc
 
-testDirectoryFail :: (Cradle Void -> Bool) -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
-testDirectoryFail cradlePred fp cradleFailPred step = do
-  a_fp <- canonicalizePath fp
-  crd <- initialiseCradle cradlePred a_fp step
-  step "Initialise Flags"
-  testLoadFileCradleFail crd a_fp cradleFailPred step
+testDirectoryFail :: (Cradle Void -> Bool) -> FilePath -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
+testDirectoryFail cradlePred rootDir file cradleFailPred step = do
+  withTempCopy rootDir $ \rootDir' -> do
+    fp <- canonicalizePath (rootDir' </> file)
+    crd <- initialiseCradle cradlePred fp step
+    step "Initialise Flags"
+    testLoadFileCradleFail crd fp cradleFailPred step
 
 initialiseCradle :: (Cradle Void -> Bool) -> FilePath -> (String -> IO ()) -> IO (Cradle Void)
 initialiseCradle cradlePred a_fp step = do
@@ -201,30 +202,32 @@ testLoadFile crd a_fp step = do
 
 testLoadFileCradleFail :: Cradle a -> FilePath -> (CradleError -> Expectation) -> (String -> IO ()) -> IO ()
 testLoadFileCradleFail crd a_fp cradleErrorExpectation step = do
-  libDir <- getRuntimeGhcLibDir crd
-  withCurrentDirectory (cradleRootDir crd) $
-    G.runGhc libDir $ do
-      let relFp = makeRelative (cradleRootDir crd) a_fp
-      res <- initializeFlagsWithCradleWithMessage (Just (\_ n _ _ -> step (show n))) relFp crd
-      case res of
-        CradleSuccess _ -> liftIO $ expectationFailure "Cradle loaded successfully"
-        CradleNone -> liftIO $ expectationFailure "Unexpected none-Cradle"
-        CradleFail crdlFail -> liftIO $ cradleErrorExpectation crdlFail
+  -- don't spin up a ghc session, just run the opts program manually since
+  -- we're not guaranteed to be able to get the ghc libdir if the cradle is
+  -- failing
+  withCurrentDirectory (cradleRootDir crd) $ do
+    let relFp = makeRelative (cradleRootDir crd) a_fp
+    res <- runCradle (cradleOptsProg crd) (step . show) relFp
+    case res of
+      CradleSuccess _ -> liftIO $ expectationFailure "Cradle loaded successfully"
+      CradleNone -> liftIO $ expectationFailure "Unexpected none-Cradle"
+      CradleFail crdlFail -> liftIO $ cradleErrorExpectation crdlFail
 
-testLoadCradleDependencies :: (Cradle Void -> Bool) -> FilePath -> ([FilePath] -> Expectation) -> (String -> IO ()) -> IO ()
-testLoadCradleDependencies cradlePred fp dependencyPred step = do
-  a_fp <- canonicalizePath fp
-  crd <- initialiseCradle cradlePred a_fp step
-  libDir <- getRuntimeGhcLibDir crd
-  step "Initialise Flags"
-  withCurrentDirectory (cradleRootDir crd) $
-    G.runGhc libDir $ do
-      let relFp = makeRelative (cradleRootDir crd) a_fp
-      res <- initializeFlagsWithCradleWithMessage (Just (\_ n _ _ -> step (show n))) relFp crd
-      case res of
-        CradleSuccess (_, options) -> liftIO $ dependencyPred (componentDependencies options)
-        CradleNone -> liftIO $ expectationFailure "Unexpected none-Cradle"
-        CradleFail (CradleError _deps _ex stde) -> liftIO $ expectationFailure ("Unexpected cradle fail" ++ unlines stde)
+testLoadCradleDependencies :: (Cradle Void -> Bool) -> FilePath -> FilePath -> ([FilePath] -> Expectation) -> (String -> IO ()) -> IO ()
+testLoadCradleDependencies cradlePred rootDir file dependencyPred step =
+  withTempCopy rootDir $ \rootDir' -> do
+    a_fp <- canonicalizePath (rootDir' </> file)
+    crd <- initialiseCradle cradlePred a_fp step
+    libDir <- getRuntimeGhcLibDir crd
+    step "Initialise Flags"
+    withCurrentDirectory (cradleRootDir crd) $
+      G.runGhc libDir $ do
+        let relFp = makeRelative (cradleRootDir crd) a_fp
+        res <- initializeFlagsWithCradleWithMessage (Just (\_ n _ _ -> step (show n))) relFp crd
+        case res of
+          CradleSuccess (_, options) -> liftIO $ dependencyPred (componentDependencies options)
+          CradleNone -> liftIO $ expectationFailure "Unexpected none-Cradle"
+          CradleFail (CradleError _deps _ex stde) -> liftIO $ expectationFailure ("Unexpected cradle fail" ++ unlines stde)
 
 findCradleForModule :: FilePath -> Maybe FilePath -> (String -> IO ()) -> IO ()
 findCradleForModule fp expected' step = do
@@ -233,22 +236,23 @@ findCradleForModule fp expected' step = do
   step "Finding cradle"
   findCradle a_fp `shouldReturn` expected
 
-testImplicitCradle :: FilePath -> ActionName Void -> FilePath -> (String -> IO ()) -> IO ()
-testImplicitCradle fp' expectedActionName expectedCradleRootDir step = do
-  fp <- makeAbsolute fp'
-  step "Inferring implicit cradle"
-  crd <- loadImplicitCradle fp :: IO (Cradle Void)
+testImplicitCradle :: FilePath -> FilePath -> ActionName Void -> (String -> IO ()) -> IO ()
+testImplicitCradle rootDir file expectedActionName step =
+  withTempCopy rootDir $ \rootDir' -> do
+    fp <- makeAbsolute (rootDir' </> file)
+    step "Inferring implicit cradle"
+    crd <- loadImplicitCradle fp :: IO (Cradle Void)
 
-  actionName (cradleOptsProg crd) `shouldBe` expectedActionName
+    actionName (cradleOptsProg crd) `shouldBe` expectedActionName
 
-  absExpectedCradleRootDir <- makeAbsolute expectedCradleRootDir
-  cradleRootDir crd `shouldBe` absExpectedCradleRootDir
+    expectedCradleRootDir <- makeAbsolute rootDir'
+    cradleRootDir crd `shouldBe` expectedCradleRootDir
 
-  step "Initialize flags"
-  testLoadFile crd fp step
+    step "Initialize flags"
+    testLoadFile crd fp step
 
-copyToTmp :: FilePath -> (FilePath -> IO a) -> IO a
-copyToTmp srcDir f =
+withTempCopy :: FilePath -> (FilePath -> IO a) -> IO a
+withTempCopy srcDir f =
   withSystemTempDirectory "hie-bios-test" $ \newDir -> do
     copyDir srcDir newDir
     f newDir
@@ -257,12 +261,14 @@ copyDir :: FilePath -> FilePath -> IO ()
 copyDir src dst = do
   contents <- listDirectory src
   forM_ contents $ \file -> do
-    let srcFp = src </> file
-        dstFp = dst </> file
-    isDir <- doesDirectoryExist srcFp
-    if isDir
-      then createDirectory dstFp >> copyDir srcFp dstFp
-      else copyFile srcFp dstFp
+    unless (file `elem` ignored) $ do
+      let srcFp = src </> file
+          dstFp = dst </> file
+      isDir <- doesDirectoryExist srcFp
+      if isDir
+        then createDirectory dstFp >> copyDir srcFp dstFp
+        else copyFile srcFp dstFp
+  where ignored = ["dist", "dist-newstyle", ".stack-work"]
       
 
 writeStackYamlFiles :: IO ()

--- a/tests/projects/failing-cabal/failing-cabal.cabal
+++ b/tests/projects/failing-cabal/failing-cabal.cabal
@@ -7,7 +7,7 @@ build-type:          Simple
 
 library
   exposed-modules:     MyLib
-  build-depends:       base >=4.13 && <4.14,
+  build-depends:       base >=4,
                        containers < 1 && > 1
                        --         ^^^^^^^^^^ <<< Invalid constraint
   default-language:    Haskell2010

--- a/tests/projects/implicit-cabal-deep-project/Main.hs
+++ b/tests/projects/implicit-cabal-deep-project/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/tests/projects/implicit-cabal-deep-project/README
+++ b/tests/projects/implicit-cabal-deep-project/README
@@ -1,0 +1,3 @@
+Here we are testing that if we have a nested cabal package but a cabal.project
+a directory above it, hie-bios will implicitly pick up the cabal.project and
+NOT the nested cabal package

--- a/tests/projects/implicit-cabal-deep-project/cabal.project
+++ b/tests/projects/implicit-cabal-deep-project/cabal.project
@@ -1,0 +1,2 @@
+packages: .
+          foo

--- a/tests/projects/implicit-cabal-deep-project/foo/Main.hs
+++ b/tests/projects/implicit-cabal-deep-project/foo/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/tests/projects/implicit-cabal-deep-project/foo/foo.cabal
+++ b/tests/projects/implicit-cabal-deep-project/foo/foo.cabal
@@ -1,0 +1,9 @@
+cabal-version:       >=1.10
+name:                foo
+version:             0.1.0.0
+build-type:          Simple
+
+executable foo
+  main-is:             Main.hs
+  build-depends:       base >=4
+  default-language:    Haskell2010

--- a/tests/projects/implicit-cabal-deep-project/implicit-cabal-deep-project.cabal
+++ b/tests/projects/implicit-cabal-deep-project/implicit-cabal-deep-project.cabal
@@ -1,0 +1,8 @@
+cabal-version:       >=1.10
+name:                implicit-cabal-deep-project
+version:             0.1.0.0
+build-type:          Simple
+executable foo
+  main-is:             Main.hs
+  build-depends:       base >=4
+  default-language:    Haskell2010

--- a/tests/projects/implicit-cabal-no-project/Main.hs
+++ b/tests/projects/implicit-cabal-no-project/Main.hs
@@ -1,0 +1,1 @@
+main = pure ()

--- a/tests/projects/implicit-cabal-no-project/implicit-cabal-no-project.cabal
+++ b/tests/projects/implicit-cabal-no-project/implicit-cabal-no-project.cabal
@@ -1,0 +1,8 @@
+cabal-version:       >=1.10
+name:                implicit-cabal-no-project
+version:             0.1.0.0
+build-type:          Simple
+executable foo
+  main-is:             Main.hs
+  build-depends:       base >=4
+  default-language:    Haskell2010


### PR DESCRIPTION
A cabal cradle doesn't need a cabal.project file and isn't guaranteed to have one either. This improves the implicit cradle search for cabal by falling back to finding .cabal files if hie-bios couldn't find any cabal.project files.
Because it falls back, if hie-bios tries to query a multi-package cabal project with a nested cabal package, it will still find use the "larger" cradle with the upper cabal.project file. See the implicit-cabal-deep-project test project for an example of this.