### PR TITLE
Revert "Add a mechanism to prevent hie-bios from searching upwards (#136)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,30 +308,6 @@ This is useful if you are designing a new build system or the other modes
 fail to setup the correct session for some reason. For example, this is
 how hadrian (GHC's build system) is integrated into `hie-bios`.
 
-
-## .hie-bios.stop files
-
-Say you have a setup like
-
-```
-- hie.yaml
-- foo.cabal
-- subdir
-  - bar.cabal
-```
-
-Calling `loadImplicitCradle` or `findCradle` will search upwards and find the
-`foo.cabal` and `hie.yaml` files. Inserting a ".hie-bios.stop" file will prevent
-this.
-
-```
-- hie.yaml
-- foo.cabal
-- subdir
-  - .hie-bios.stop
-  - bar.cabal
-```
-
 ## Supporting Bazel and Obelisk
 
 In previous versions of `hie-bios` there was also support for projects using `rules_haskell` and `obelisk`.

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -136,13 +136,6 @@ Extra-Source-Files:     ChangeLog
                         tests/projects/implicit-stack-multi/other-package/Setup.hs
                         tests/projects/implicit-stack-multi/other-package/other-package.cabal
                         tests/projects/implicit-stack-multi/other-package/Main.hs
-                        tests/projects/stop-file/Main.hs
-                        tests/projects/stop-file/hie.yaml
-                        tests/projects/stop-file/stop-file.cabal
-                        tests/projects/stop-file/sub-package/Main.hs
-                        tests/projects/stop-file/sub-package/sub-package.cabal
-                        tests/projects/stop-file/sub-package/cabal.project
-                        tests/projects/stop-file/sub-package/.hie-bios.stop
 
 
 tested-with: GHC==8.10.1, GHC==8.8.3, GHC==8.6.5, GHC==8.4.4

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -709,7 +709,6 @@ obeliskAction work_dir _fp = do
 
 -- | Searches upwards for the first directory containing a file to match
 -- the predicate.
--- Stops searching upwards if there is a ".hie-bios.stop" file in the directory.
 findFileUpwards :: (FilePath -> Bool) -> FilePath -> MaybeT IO FilePath
 findFileUpwards p dir = do
   cnts <-
@@ -720,10 +719,9 @@ findFileUpwards p dir = do
         pure
         (findFile p dir)
 
-  stopFileExists <- liftIO $ doesFileExist (dir </> ".hie-bios.stop")
   case cnts of
-    [] | dir' == dir || stopFileExists -> fail "No cabal files"
-       | otherwise                     -> findFileUpwards p dir'
+    [] | dir' == dir -> fail "No cabal files"
+            | otherwise   -> findFileUpwards p dir'
     _ : _ -> return dir
   where dir' = takeDirectory dir
 

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -45,15 +45,6 @@ main = do
                   (Just "./tests/projects/simple-cabal/hie.yaml")
                 )
         ]
-      , testGroup "Stop files"
-        [ testCaseSteps "findCradle" $ \_ -> do
-            yamlFile <- findCradle "./tests/projects/stop-file/sub-package/Main.hs"
-            unless (yamlFile == Nothing) (error "Didn't respect stop file")
-        , testCaseSteps "loadImplicitCradle" $ \_ -> do
-            crd <- loadImplicitCradle "./tests/projects/stop-file/sub-package/Main.hs"  :: IO (Cradle Void)
-            unless (actionName (cradleOptsProg crd) == Cabal) $
-              error $ "Didn't respect stop file: " <> show crd
-        ]
       , testGroup "Loading tests"
         $ linuxExlusiveTestCases
         ++

--- a/tests/projects/stop-file/Main.hs
+++ b/tests/projects/stop-file/Main.hs
@@ -1,1 +1,0 @@
-main = pure ()

--- a/tests/projects/stop-file/hie.yaml
+++ b/tests/projects/stop-file/hie.yaml
@@ -1,2 +1,0 @@
-cradle:
-    stack:

--- a/tests/projects/stop-file/stop-file.cabal
+++ b/tests/projects/stop-file/stop-file.cabal
@@ -1,9 +1,0 @@
-cabal-version:       >=1.10
-name:                stop-file
-version:             0.1.0.0
-build-type:          Simple
-
-executable stop-file
-  main-is:             Main.hs
-  build-depends:       base
-  default-language:    Haskell2010

--- a/tests/projects/stop-file/sub-package/Main.hs
+++ b/tests/projects/stop-file/sub-package/Main.hs
@@ -1,1 +1,0 @@
-main = pure ()

--- a/tests/projects/stop-file/sub-package/cabal.project
+++ b/tests/projects/stop-file/sub-package/cabal.project
@@ -1,1 +1,0 @@
-packages: .

--- a/tests/projects/stop-file/sub-package/sub-package.cabal
+++ b/tests/projects/stop-file/sub-package/sub-package.cabal
@@ -1,9 +1,0 @@
-cabal-version:       >=1.10
-name:                sub-package
-version:             0.1.0.0
-build-type:          Simple
-
-executable sub-package
-  main-is:             Main.hs
-  build-depends:       base
-  default-language:    Haskell2010


### PR DESCRIPTION
No longer needed now that we just copy tests to a temporary directory