### PR TITLE
Expose 'readProcessWithCwd'

### DIFF
--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -18,6 +18,7 @@ module HIE.Bios.Cradle (
     , isOtherCradle
     , getCradle
     , readProcessWithOutputFile
+    , readProcessWithCwd
     , makeCradleResult
   ) where
 


### PR DESCRIPTION
Should make it easier for downstream consumers