### PR TITLE
Add tests for bios dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,12 +523,12 @@ cradle:
 ```yaml
 cradle:
   bios:
-    shell: build-tool flags $HIE_BIOS_ARG
-    dependency-shell: build-tool dependencies
+    shell: build-tool flags $HIE_BIOS_ARG $HIE_BIOS_OUTPUT
+    dependency-shell: build-tool dependencies $HIE_BIOS_OUTPUT
 ```
 
 The dependency program or command is executed with no parameters and it is
-expected to output on stdout on each line exactly one filepath relative
+expected to output on HIE_BIOS_OUTPUT on each line exactly one filepath relative
 to the root of the cradle, not relative to the location of the program.
 
 Programs and shell commands for flags and dependencies can be mixed and matched.

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -176,7 +176,7 @@ linuxExlusiveTestCases
   | not isWindows
   = [ testCaseSteps "simple-bios" $ testDirectory isBiosCradle "./tests/projects/simple-bios" "B.hs"
     , testCaseSteps "simple-bios-ghc" $ testDirectory isBiosCradle "./tests/projects/simple-bios-ghc" "B.hs"
-    , testCaseSteps "simple-bios-deps" $ testLoadCradleDependencies isBiosCradle "./tests/projects/simple-bios" "B.hs" (assertEqual "dependencies" ["hie.yaml", "hie-bios.sh"])
+    , testCaseSteps "simple-bios-deps" $ testLoadCradleDependencies isBiosCradle "./tests/projects/simple-bios" "B.hs" (assertEqual "dependencies" ["hie-bios.sh", "hie.yaml"])
     ]
   | otherwise
   = []

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -106,6 +106,7 @@ main = do
                   length cradleErrorStderr `shouldBe` 1
                   head cradleErrorStderr `shouldStartWith` "Couldn't execute myGhc")
            , testCaseSteps "simple-bios-shell" $ testDirectory isBiosCradle "./tests/projects/simple-bios-shell" "B.hs"
+           , testCaseSteps "simple-bios-shell-deps" $ testLoadCradleDependencies isBiosCradle "./tests/projects/simple-bios-shell" "B.hs" (assertEqual "dependencies" ["hie.yaml"])
            , testCaseSteps "simple-cabal" $ testDirectory isCabalCradle "./tests/projects/simple-cabal" "B.hs"
            , testCaseSteps "simple-direct" $ testDirectory isDirectCradle "./tests/projects/simple-direct" "B.hs"
            , testCaseSteps "nested-cabal" $ testLoadCradleDependencies isCabalCradle "./tests/projects/nested-cabal" "sub-comp/Lib.hs"
@@ -175,6 +176,7 @@ linuxExlusiveTestCases
   | not isWindows
   = [ testCaseSteps "simple-bios" $ testDirectory isBiosCradle "./tests/projects/simple-bios" "B.hs"
     , testCaseSteps "simple-bios-ghc" $ testDirectory isBiosCradle "./tests/projects/simple-bios-ghc" "B.hs"
+    , testCaseSteps "simple-bios-deps" $ testLoadCradleDependencies isBiosCradle "./tests/projects/simple-bios" "B.hs" (assertEqual "dependencies" ["hie.yaml", "hie-bios.sh"])
     ]
   | otherwise
   = []

--- a/tests/projects/simple-bios-shell/hie.yaml
+++ b/tests/projects/simple-bios-shell/hie.yaml
@@ -9,6 +9,6 @@ cradle:
       ECHO "A" >> %HIE_BIOS_OUTPUT%
       ECHO "B" >> %HIE_BIOS_OUTPUT%
     dependency-shell: |
-      echo -n # > nul && ECHO hie.yaml >> %HIE_BIOS_OUTPUT%
+      echo -n # > nul && ECHO hie.yaml>> %HIE_BIOS_OUTPUT%
       :; echo "hie.yaml" >> $HIE_BIOS_OUTPUT
       :; exit 0

--- a/tests/projects/simple-bios-shell/hie.yaml
+++ b/tests/projects/simple-bios-shell/hie.yaml
@@ -9,6 +9,6 @@ cradle:
       ECHO "A" >> %HIE_BIOS_OUTPUT%
       ECHO "B" >> %HIE_BIOS_OUTPUT%
     dependency-shell: |
+      echo -n # > nul && ECHO hie.yaml >> %HIE_BIOS_OUTPUT%
       :; echo "hie.yaml" >> $HIE_BIOS_OUTPUT
       :; exit 0
-      ECHO "hie.yaml" >> %HIE_BIOS_OUTPUT%

--- a/tests/projects/simple-bios-shell/hie.yaml
+++ b/tests/projects/simple-bios-shell/hie.yaml
@@ -9,6 +9,6 @@ cradle:
       ECHO "A" >> %HIE_BIOS_OUTPUT%
       ECHO "B" >> %HIE_BIOS_OUTPUT%
     dependency-shell: |
-      :; echo "hie.yaml"
+      :; echo "hie.yaml" >> $HIE_BIOS_OUTPUT
       :; exit 0
-      ECHO "hie.yaml"
+      ECHO "hie.yaml" >> %HIE_BIOS_OUTPUT%

--- a/tests/projects/simple-bios-shell/hie.yaml
+++ b/tests/projects/simple-bios-shell/hie.yaml
@@ -8,3 +8,7 @@ cradle:
       ECHO "-Wall" >> %HIE_BIOS_OUTPUT%
       ECHO "A" >> %HIE_BIOS_OUTPUT%
       ECHO "B" >> %HIE_BIOS_OUTPUT%
+    dependency-shell: |
+      :; echo "hie.yaml"
+      :; exit 0
+      ECHO "hie.yaml"

--- a/tests/projects/simple-bios/hie-bios-deps.sh
+++ b/tests/projects/simple-bios/hie-bios-deps.sh
@@ -1,1 +1,1 @@
-echo "hie-bios.sh"
+echo "hie-bios.sh" >> $HIE_BIOS_OUTPUT

--- a/tests/projects/simple-bios/hie-bios-deps.sh
+++ b/tests/projects/simple-bios/hie-bios-deps.sh
@@ -1,0 +1,1 @@
+echo "hie-bios.sh"

--- a/tests/projects/simple-bios/hie.yaml
+++ b/tests/projects/simple-bios/hie.yaml
@@ -3,4 +3,5 @@ cradle:
     program: ./hie-bios.sh
     dependency-program: ./hie-bios-deps.sh
 
-  dependencies: hie.yaml
+dependencies:
+    - hie.yaml

--- a/tests/projects/simple-bios/hie.yaml
+++ b/tests/projects/simple-bios/hie.yaml
@@ -1,2 +1,6 @@
 cradle:
-  bios: {program: ./hie-bios.sh }
+  bios:
+    program: ./hie-bios.sh
+    dependency-program: ./hie-bios-deps.sh
+
+  dependencies: hie.yaml


### PR DESCRIPTION
I ran into issues trying to define component dependencies in my Bios cradles, and wrote a pair of failing tests to demonstrate. 
Please check that I'm not missing anything, and let me know if there is an obvious fix.