### PR TITLE
Add explicit type for stack.yaml location

### DIFF
--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RecordWildCards, CPP #-}
-module HIE.Bios.Environment (initSession, getRuntimeGhcLibDir, getRuntimeGhcVersion, makeDynFlagsAbsolute, makeTargetsAbsolute, getCacheDir, addCmdOpts) where
+module HIE.Bios.Environment (initSession, getRuntimeGhcLibDir, getRuntimeGhcVersion, makeDynFlagsAbsolute, makeTargetsAbsolute, prependIfRelative, getCacheDir, addCmdOpts) where
 
 import CoreMonad (liftIO)
 import GHC (GhcMonad)
@@ -75,7 +75,7 @@ getRuntimeGhcLibDir :: Cradle a
                     -> IO (CradleLoadResult FilePath)
 getRuntimeGhcLibDir cradle = do
   maybeNixLibDir <- lookupEnv "NIX_GHC_LIBDIR"
-  case maybeNixLibDir of 
+  case maybeNixLibDir of
     Just ld -> pure (CradleSuccess ld)
     Nothing -> fmap (fmap trim) $
       runGhcCmd (cradleOptsProg cradle) ["--print-libdir"]


### PR DESCRIPTION
Also, if no stack.yaml was given, don't default to "stack.yaml"


This also fixes a regression. Assume the following setup:
``` sh
> cat File.hs
module File where

foo :: Int
foo = 2
> cat hie.yaml
cradle:
  stack:
> hie-bios check File.hs
```

This used to work, as we simply invoked `stack repl` to find the project arguments 