### PR TITLE
Require aeson 1.4.5

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -142,7 +142,7 @@ Library
   autogen-modules:      Paths_hie_bios
   Build-Depends:
                         base                 >= 4.8 && < 5,
-                        aeson                >= 1.4.1 && < 2,
+                        aeson                >= 1.4.5 && < 2,
                         base16-bytestring    >= 0.1.1 && < 0.2,
                         bytestring           >= 0.10.8 && < 0.11,
                         deepseq              >= 1.4.3 && < 1.5,


### PR DESCRIPTION
We rely on JSONPath, which only got exposed in 1.4.5.