### PR TITLE
Bump upper bound of base16-bytestring

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -143,7 +143,7 @@ Library
   Build-Depends:
                         base                 >= 4.8 && < 5,
                         aeson                >= 1.4.5 && < 2,
-                        base16-bytestring    >= 0.1.1 && < 0.2,
+                        base16-bytestring    >= 0.1.1 && < 1.1,
                         bytestring           >= 0.10.8 && < 0.11,
                         deepseq              >= 1.4.3 && < 1.5,
                         containers           >= 0.5.10 && < 0.7,


### PR DESCRIPTION
closes #251 
