### PR TITLE
Log stderr of `stack exec ghc` for better feedback

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # ChangeLog hie-bios
 
+## TBA - 0.7.6
+
+* Log stderr of stack to display more informative error messages to users. [#254](https://github.com/mpickering/hie-bios/pull/254)
 ## 2021-03-21 - 0.7.5
 
 ### Bug Fixes

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   hie-bios
-Version:                0.7.5
+Version:                0.7.6
 Author:                 Matthew Pickering <matthewtpickering@gmail.com>
 Maintainer:             Matthew Pickering <matthewtpickering@gmail.com>
 License:                BSD-3-Clause

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -174,7 +174,7 @@ configFileName :: FilePath
 configFileName = "hie.yaml"
 
 -- | Pass '-dynamic' flag when GHC is built with dynamic linking.
--- 
+--
 -- Append flag to options of 'defaultCradle' and 'directCradle' if GHC is dynmically linked,
 -- because unlike the case of using build tools, which means '-dynamic' can be set via
 -- '.cabal' or 'package.yaml', users have to create an explicit hie.yaml to pass this flag.
@@ -608,10 +608,14 @@ stackCradle wdir mc syaml =
     , cradleOptsProg   = CradleAction
         { actionName = Types.Stack
         , runCradle = stackAction wdir mc syaml
-        , runGhcCmd = \args ->
-            readProcessWithCwd wdir "stack"
-              (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
-              ""
+        , runGhcCmd = \args -> do
+            -- Setup stack silently, since stack might print stuff to stdout in some cases (e.g. on Win)
+            -- Issue 242 from HLS: https://github.com/haskell/haskell-language-server/issues/242
+            stackSetup <- readProcessWithCwd wdir "stack" (stackYamlProcessArgs syaml <> ["setup", "--silent"]) ""
+            stackSetup `bindIO` \_ ->
+              readProcessWithCwd wdir "stack"
+                (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
+                ""
         }
     }
 

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -610,7 +610,7 @@ stackCradle wdir mc syaml =
         , runCradle = stackAction wdir mc syaml
         , runGhcCmd = \args ->
             readProcessWithCwd wdir "stack"
-              (stackYamlProcessArgs syaml <> ["exec", "--silent", "ghc", "--"] <> args)
+              (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
               ""
         }
     }

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+{-# LANGUAGE DeriveFoldable #-}
+{-# LANGUAGE DeriveTraversable #-}
 module HIE.Bios.Types where
 
 import           System.Exit
@@ -74,7 +76,26 @@ data CradleLoadResult r
   = CradleSuccess r -- ^ The cradle succeeded and returned these options.
   | CradleFail CradleError -- ^ We tried to load the cradle and it failed.
   | CradleNone -- ^ No attempt was made to load the cradle.
-  deriving (Functor, Show, Eq)
+ deriving (Functor, Foldable, Traversable, Show, Eq)
+
+
+instance Applicative CradleLoadResult where
+  pure = CradleSuccess
+  CradleSuccess a <*> CradleSuccess b = CradleSuccess (a b)
+  CradleFail err <*> _ = CradleFail err
+  _ <*> CradleFail err = CradleFail err
+  _ <*> _ = CradleNone
+
+instance Monad CradleLoadResult where
+  return = CradleSuccess
+  CradleSuccess r >>= k = k r
+  CradleFail err >>= _ = CradleFail err
+  CradleNone >>= _ = CradleNone
+
+bindIO :: CradleLoadResult a -> (a -> IO (CradleLoadResult b)) -> IO (CradleLoadResult b)
+bindIO  (CradleSuccess r) k = k r
+bindIO (CradleFail err) _ = return $ CradleFail err
+bindIO CradleNone _ = return CradleNone
 
 
 data CradleError = CradleError


### PR DESCRIPTION
From Freenode #haskell-ide-engine we had a line such as:

> Failed to get project GHC version:CradleError {cradleErrorDependencies = [], cradleErrorExitCode = ExitFailure 1, cradleErrorStderr = ["Error when calling stack exec --silent ghc -- --numeric-version","",""]}

and you have to run `stack exec --silent ghc -- --numeric-version` to actually see the error.
The error was then:
```
Cannot open: Disk quota exceeded
```

If this was included in the above log line, it would have been easier to debug.

Smoke testing showed that `--silent` is not necessary as such log output was sent to stderr.
