### PR TITLE
Only take the last line of output in getRuntimeGhcX

### DIFF
--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -309,5 +309,9 @@ anyToken :: ReadP Char
 anyToken = satisfy $ const True
 
 -- Used for clipping the trailing newlines on GHC output
+-- Also only take the last line of output
+-- (Stack's ghc output has a lot of preceding noise from 7zip etc)
 trim :: String -> String
-trim = dropWhileEnd isSpace
+trim s = case lines s of
+  [] -> s
+  ls -> dropWhileEnd isSpace $ last ls


### PR DESCRIPTION
Fixes cases on windows where stack's output looks like this:

```
\n7-Zip 9.20  Copyright (c) 1999-2010 Igor Pavlov  2010-11-18\n\nProcessing archive: C:\\Users\\runneradmin\\AppData\\Local\\Programs\\stack\\x86_64-windows\\ghc-8.8.3.tar.xz\n\nExtracting  ghc-8.8.3.tar\n\nEverything is Ok\n\nSize:       2555330560\nCompressed: 204702116\n8.8.3
```