### PR TITLE
Faster Bios protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,29 +560,23 @@ dependencies:
   - default.nix
 ```
 
-For the `Bios` cradle type, there is an optional field for specifying a program
-or shell command to obtain cradle dependencies from:
+For the `Bios` cradle type, the newline-separated cradle dependencies must be written out
+to the file specified by the `HIE_BIOS_DEPS` environment variable.
+
+Previous versions implemented a different mechanism for collecting cradle dependencies
+by means of a second program/shell field. This is still supported for backwards
+compatibility:
 
 ```yaml
 cradle:
   bios:
-    program: ./flags.sh
     dependency-program: ./dependency.sh
 ```
 ```yaml
 cradle:
   bios:
-    shell: build-tool flags $HIE_BIOS_ARG > $HIE_BIOS_OUTPUT
     dependency-shell: build-tool dependencies $HIE_BIOS_ARG > $HIE_BIOS_OUTPUT
 ```
-
-The dependency program or command is executed in a similar fashion to the bios
-program, using the environment variables HIE_BIOS_ARG and HIE_BIOS_OUTPUT to
-communicate respectively the path of the source file being loaded, and the path
-where the set of dependency paths should be written, one per line,
-and relative to the root of the cradle, not to the location of the program.
-
-Programs and shell commands for flags and dependencies can be mixed and matched.
 
 ## Configuration specification
 

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -19,6 +19,10 @@ Extra-Source-Files:     ChangeLog.md
                         tests/configs/*.yaml
                         tests/projects/symlink-test/a/A.hs
                         tests/projects/symlink-test/hie.yaml
+                        tests/projects/deps-bios-new/A.hs
+                        tests/projects/deps-bios-new/B.hs
+                        tests/projects/deps-bios-new/hie-bios.sh
+                        tests/projects/deps-bios-new/hie.yaml
                         tests/projects/multi-direct/A.hs
                         tests/projects/multi-direct/B.hs
                         tests/projects/multi-direct/hie.yaml

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -795,10 +795,9 @@ getCleanEnvironment = do
 type Outputs = [OutputName]
 type OutputName = String
 
--- | Call a given process.
--- * A special file is created for the process to write to, the process can discover the name of
--- the file by reading the @HIE_BIOS_OUTPUT@ environment variable. The contents of this file is
--- returned by the function.
+-- | Call a given process with temp files for the process to write to.
+-- * The process can discover the temp files paths by reading the environment.
+-- * The contents of the temp files are returned by this function, if any.
 -- * The logging function is called every time the process emits anything to stdout or stderr.
 -- it can be used to report progress of the process to a user.
 -- * The process is executed in the given directory.

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -375,8 +375,12 @@ biosAction :: FilePath
            -> IO (CradleLoadResult ComponentOptions)
 biosAction wdir bios bios_deps l fp = do
   bios' <- callableToProcess bios (Just fp)
-  (ex, _stdo, std, [(_, res)]) <- readProcessWithOutputs [hie_bios_output] l wdir bios'
-  deps <- biosDepsAction l wdir bios_deps fp
+  (ex, _stdo, std, [(_, res),(_, mb_deps)]) <-
+    readProcessWithOutputs [hie_bios_output, "HIE_BIOS_DEPS"] l wdir bios'
+
+  deps <- case mb_deps of
+    Just x  -> return x
+    Nothing -> biosDepsAction l wdir bios_deps fp
         -- Output from the program should be written to the output file and
         -- delimited by newlines.
         -- Execute the bios action and add dependencies of the cradle.

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -183,6 +183,7 @@ linuxExlusiveTestCases
   = [ testCaseSteps "simple-bios" $ testDirectory isBiosCradle "./tests/projects/simple-bios" "B.hs"
     , testCaseSteps "simple-bios-ghc" $ testDirectory isBiosCradle "./tests/projects/simple-bios-ghc" "B.hs"
     , testCaseSteps "simple-bios-deps" $ testLoadCradleDependencies isBiosCradle "./tests/projects/simple-bios" "B.hs" (assertEqual "dependencies" ["hie-bios.sh", "hie.yaml"])
+    , testCaseSteps "simple-bios-deps-new" $ testLoadCradleDependencies isBiosCradle "./tests/projects/deps-bios-new" "B.hs" (assertEqual "dependencies" ["hie-bios.sh", "hie.yaml"])
     ]
   | otherwise
   = []

--- a/tests/projects/deps-bios-new/A.hs
+++ b/tests/projects/deps-bios-new/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/tests/projects/deps-bios-new/B.hs
+++ b/tests/projects/deps-bios-new/B.hs
@@ -1,0 +1,3 @@
+module B where
+
+import A

--- a/tests/projects/deps-bios-new/hie-bios.sh
+++ b/tests/projects/deps-bios-new/hie-bios.sh
@@ -1,0 +1,5 @@
+echo "-Wall" >> $HIE_BIOS_OUTPUT
+echo "A" >> $HIE_BIOS_OUTPUT
+echo "B" >> $HIE_BIOS_OUTPUT
+echo "hie-bios.sh" >> $HIE_BIOS_DEPS
+echo "hie.yaml" >> $HIE_BIOS_DEPS

--- a/tests/projects/deps-bios-new/hie.yaml
+++ b/tests/projects/deps-bios-new/hie.yaml
@@ -1,0 +1,3 @@
+cradle:
+  bios:
+    program: ./hie-bios.sh


### PR DESCRIPTION
This implements the proposal in #270 to obtain the OUTPUTS and DEPS in a single run.

The implementation is careful to preserve backwards compatibility. If both the new and old mechanisms are used, the new mechanism takes precedence.