### PR TITLE
Add a default .hlint.yaml file, disabling all hints currently triggered

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,80 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
+
+
+# Warnings currently triggered by your code
+- ignore: {name: "Use newtype instead of data"}
+- ignore: {name: "Use camelCase"}
+- ignore: {name: "Redundant $"}
+- ignore: {name: "Redundant bracket"}
+- ignore: {name: "Functor law"}
+- ignore: {name: "Use catMaybes"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Use const"}
+- ignore: {name: "Move brackets to avoid $"}
+- ignore: {name: "Parse error: possibly incorrect indentation or mismatched brackets"}
+
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+# The hints are named by the string they display in warning messages.
+# For example, if you see a warning starting like
+#
+# Main.hs:116:51: Warning: Redundant ==
+#
+# You can refer to that hint with `{name: Redundant ==}` (see below).
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,7 +17,7 @@
 - ignore: {name: "Eta reduce"}
 - ignore: {name: "Use const"}
 - ignore: {name: "Move brackets to avoid $"}
-- ignore: {name: "Parse error: possibly incorrect indentation or mismatched brackets"}
+- ignore: {name: "Parse error"}
 
 
 # Specify additional command line arguments


### PR DESCRIPTION
Otherwise people might mistakenly try and send patches fixing them, e.g. #277. Also ensures they aren't shown in the IDE.

FWIW, the one that I would totally apply is:

```
src\HIE\Bios\Cradle.hs:637:26-53: Suggestion: Use catMaybes
Found:
  [comp | Just comp <- [mc]]
Perhaps:
  Data.Maybe.catMaybes [mc]
```

That seems much cleaner. Everything else has both pros and cons.