### PR TITLE
Add job to compile the windows wrapper in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -8,17 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ['8.10.1', '8.8.3', '8.6.5', '8.4.4']
+        ghc: ['8.10.4', '8.8.4', '8.6.5', '8.4.4']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         exclude:
-          - os: windows-latest
-            ghc: '8.8.3' # fails due to segfault
           - os: macOS-latest
             ghc: '8.4.4' # fails due to ghc panic
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: '3.2'
@@ -40,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: haskell/actions/setup@v1
     - name: Check
       run: cabal check
     - name: Generate sdist
@@ -57,3 +55,13 @@ jobs:
     - uses: ludeeus/action-shellcheck@master
       with:
         ignore: tests
+
+  windows-wrapper:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: haskell/actions/setup@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+    - name: Compile Windows wrapper
+      run: ghc -hide-all-packages -package base -package directory -package process -Wall -Werror wrappers/cabal.hs -o CabalWrapper

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -372,17 +372,17 @@ stackYaml resolver pkgs = unlines
 stackYamlResolver :: String
 stackYamlResolver =
 #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,10,1,0)))
-  "nightly-2020-06-25"
+  "lts-17.7" -- GHC 8.10.4
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,8,1,0)))
-  "lts-15.10"
+  "lts-16.31" -- GHC 8.8.4
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,6,5,0)))
-  "lts-14.17"
+  "lts-14.27" -- GHC 8.6.5
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,6,4,0)))
-  "lts-13.19"
+  "lts-13.19" -- GHC 8.6.4
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,4,0)))
-  "lts-12.26"
+  "lts-12.26" -- GHC 8.4.4
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,3,0)))
-  "lts-12.26"
+  "lts-12.14" -- GHC 8.4.3
 #elif (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
-  "lts-11.22"
+  "lts-11.22" -- GHC 8.2.2
 #endif


### PR DESCRIPTION
Since travis kind of stopped working, we compile the wrappers to find warnings and have a higher confidence that it is working