### PR TITLE
Add dynamic way to the session for dynamic GHC

### DIFF
--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -44,6 +44,7 @@ initSession  ComponentOptions {..} = do
         $ setIgnoreInterfacePragmas            -- Ignore any non-essential information in interface files such as unfoldings changing.
         $ writeInterfaceFiles (Just cache_dir) -- Write interface files to the cache
         $ setVerbosity 0                       -- Set verbosity to zero just in case the user specified `-vx` in the options.
+        $ (if dynamicGhc then updateWays . addWay' WayDyn else id) -- Add dynamic way if GHC is built with dynamic linking 
         $ setLinkerOptions df''                 -- Set `-fno-code` to avoid generating object files, unless we have to.
         )
 


### PR DESCRIPTION
Test suite passes on Arch Linux by adding this, otherwise we get:

```
Running 1 test suites...
Test suite bios-tests: RUNNING...
Bios-tests
  Find cradle
    simple-cabal:                                  OK
      Finding cradle
    simple-cabal-unknown-path:                     OK
      Finding cradle
  Symlink
    Can load base module:                          OK
      Finding Cradle for: /tmp/hie-bios-test-43a11c2708badfc6/
      Loading Cradle: Just "/tmp/hie-bios-test-43a11c2708badfc6/hie.yaml"
      Load module A
    Can load symlinked module:                     OK
      Finding Cradle for: /tmp/hie-bios-test-f6c392e2f41cabac/
      Loading Cradle: Just "/tmp/hie-bios-test-f6c392e2f41cabac/hie.yaml"
      Attemp to load symlinked module A
    Can not load symlinked module that is ignored: OK
      Finding Cradle for: /tmp/hie-bios-test-3a9132cd4afc6408/
      Loading Cradle: Just "/tmp/hie-bios-test-3a9132cd4afc6408/hie.yaml"
      Attemp to load symlinked module A
  Loading tests
    simple-bios:                                   FAIL (0.20s)
      Finding Cradle for: /tmp/hie-bios-test-9ab7dbc2a89d6b58/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-9ab7dbc2a89d6b58/hie.yaml"
      Get runtime GHC library directory                              (0.05s)
      Get runtime GHC version                                        (0.04s)
      Initialise Flags                                               (0.05s)
      Initial module load                                            (0.06s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    simple-bios-ghc:                               FAIL (0.17s)
      Finding Cradle for: /tmp/hie-bios-test-81c2c331e11f7f82/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-81c2c331e11f7f82/hie.yaml"
      Get runtime GHC library directory                              (0.05s)
      Get runtime GHC version                                        (0.04s)
      Initialise Flags                                               (0.05s)
      Initial module load                                            (0.04s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    simple-bios-deps:                              OK (0.05s)
      Finding Cradle for: /tmp/hie-bios-test-67d8590a44126ff9/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-67d8590a44126ff9/hie.yaml" (0.05s)
      Initialise Flags
    failing-cabal:                                 OK (1.92s)
      Finding Cradle for: /tmp/hie-bios-test-964bea4757b60037/MyLib.hs
      Loading Cradle: Just "/tmp/hie-bios-test-964bea4757b60037/hie.yaml"
      Initialise Flags                                               (1.66s)
      "Resolving dependencies..."                                    (0.25s)
      "cabal: Could not resolve dependencies:"
      "[__0] trying: failing-cabal-0.1.0.0 (user goal)"
      "[__1] next goal: containers (dependency of failing-cabal)"
      "[__1] rejecting: containers-0.6.2.1/installed-0.6.2.1 (conflict: failing-cabal"
      "=> containers<1 && >1)"
      "[__1] skipping: containers-0.6.4.1, containers-0.6.3.1, containers-0.6.2.1,"
      "containers-0.6.1.1, containers-0.6.0.1, containers-0.5.11.0,"
      "containers-0.5.10.2, containers-0.5.10.1, containers-0.5.9.2,"
      "containers-0.5.8.2, containers-0.5.7.1, containers-0.5.7.0,"
      "containers-0.5.6.3, containers-0.5.6.2, containers-0.5.6.1,"
      "containers-0.5.6.0, containers-0.5.5.1, containers-0.5.5.0,"
      "containers-0.5.4.0, containers-0.5.3.1, containers-0.5.3.0,"
      "containers-0.5.2.1, containers-0.5.2.0, containers-0.5.1.0,"
      "containers-0.5.0.0, containers-0.4.2.1, containers-0.4.2.0,"
      "containers-0.4.1.0, containers-0.4.0.0, containers-0.3.0.0,"
      "containers-0.2.0.1, containers-0.2.0.0, containers-0.1.0.1,"
      "containers-0.1.0.0, containers-0.5.9.1, containers-0.5.8.1 (has the same"
      "characteristics that caused the previous version to fail: excluded by"
      "constraint '<1 && >1' from 'failing-cabal')"
      "[__1] fail (backjumping, conflict set: containers, failing-cabal)"
      "After searching the rest of the dependency tree exhaustively, these were the"
      "goals I've had most trouble fulfilling: failing-cabal, containers"
      ""                                                             (0.01s)
    failing-bios:                                  OK
      Finding Cradle for: /tmp/hie-bios-test-87bfa2859c3cb3cb/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-87bfa2859c3cb3cb/hie.yaml"
      Initialise Flags
    failing-bios-ghc:                              OK
      Finding Cradle for: /tmp/hie-bios-test-8341b557f9edf687/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-8341b557f9edf687/hie.yaml"
      Initialise Flags
    simple-bios-shell:                             FAIL (0.17s)
      Finding Cradle for: /tmp/hie-bios-test-278275109ebb2921/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-278275109ebb2921/hie.yaml"
      Get runtime GHC library directory                              (0.05s)
      Get runtime GHC version                                        (0.04s)
      Initialise Flags                                               (0.05s)
      Initial module load                                            (0.03s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    simple-bios-shell-deps:                        OK (0.06s)
      Finding Cradle for: /tmp/hie-bios-test-f1e605230c52075e/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-f1e605230c52075e/hie.yaml" (0.05s)
      Initialise Flags
    simple-cabal:                                  FAIL (5.17s)
      Finding Cradle for: /tmp/hie-bios-test-147ff783446ebb6d/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-147ff783446ebb6d/hie.yaml"
      Get runtime GHC library directory                              (2.09s)
      Get runtime GHC version                                        (0.09s)
      Initialise Flags                                               (2.96s)
      Initial module load                                            (0.04s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    simple-direct:                                 FAIL (0.17s)
      Finding Cradle for: /tmp/hie-bios-test-dae686b81eff5eda/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-dae686b81eff5eda/hie.yaml"
      Get runtime GHC library directory                              (0.05s)
      Get runtime GHC version                                        (0.04s)
      Initialise Flags                                               (0.05s)
      Initial module load                                            (0.04s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    nested-cabal:                                  OK (4.80s)
      Finding Cradle for: /tmp/hie-bios-test-5c613ea4fe44b56d/sub-comp/Lib.hs
      Loading Cradle: Just "/tmp/hie-bios-test-5c613ea4fe44b56d/hie.yaml" (1.95s)
      Initialise Flags                                               (2.84s)
    nested-cabal2:                                 OK (4.85s)
      Finding Cradle for: /tmp/hie-bios-test-c5876e75b0cebb28/MyLib.hs
      Loading Cradle: Just "/tmp/hie-bios-test-c5876e75b0cebb28/hie.yaml" (1.97s)
      Initialise Flags                                               (2.87s)
    multi-direct:                                  FAIL (0.16s)
      Finding Cradle for: /tmp/hie-bios-test-8a4248c3c3624940/B.hs
      Loading Cradle: Just "/tmp/hie-bios-test-8a4248c3c3624940/hie.yaml"
      Get runtime GHC library directory                              (0.05s)
      Get runtime GHC version                                        (0.04s)
      Initialise Flags                                               (0.05s)
      Initial module load                                            (0.03s)
      (1,2)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    multi-cabal:                                   FAIL (5.05s)
      Finding Cradle for: /tmp/hie-bios-test-72139b20e6c14bea/src/Lib.hs
      Loading Cradle: Just "/tmp/hie-bios-test-72139b20e6c14bea/hie.yaml"
      Get runtime GHC library directory                              (1.96s)
      Get runtime GHC version                                        (0.09s)
      Initialise Flags                                               (2.96s)
      Initial module load                                            (0.04s)
      (1,1)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    monorepo-cabal:                                FAIL (5.04s)
      Finding Cradle for: /tmp/hie-bios-test-28d5a2356b3422e0/B/MyLib.hs
      Loading Cradle: Just "/tmp/hie-bios-test-28d5a2356b3422e0/hie.yaml"
      Get runtime GHC library directory                              (1.95s)
      Get runtime GHC version                                        (0.09s)
      Initialise Flags                                               (2.97s)
      Initial module load                                            (0.04s)
      (1,1)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
  Implicit cradle tests
    implicit-cabal:                                FAIL (5.12s)
      Inferring implicit cradle
      Initialize flags          (5.09s)
      Initial module load       (0.04s)
      (1,1)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    implicit-cabal-no-project:                     FAIL (4.99s)
      Inferring implicit cradle
      Initialize flags          (4.95s)
      Initial module load       (0.04s)
      (1,1)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")
    implicit-cabal-deep-project:                   FAIL (4.97s)
      Inferring implicit cradle
      Initialize flags          (4.93s)
      Initial module load       (0.03s)
      (1,1)
        HUnitFailure (Just (SrcLoc {srcLocPackage = "main", srcLocModule = "Main", srcLocFile = "tests/BiosTests.hs", srcLocStartLine = 269, srcLocStartCol = 32, srcLocEndLine = 269, srcLocEndCol = 74})) (Reason "Module loading failed")

11 out of 23 tests failed (42.91s)
Test suite bios-tests: FAIL
Test suite logged to:
/home/berberman/hie-bios/dist-newstyle/build/x86_64-linux/ghc-8.10.4/hie-bios-0.7.1/t/bios-tests/test/hie-bios-0.7.1-bios-tests.log
0 of 1 test suites (0 of 1 test cases) passed.
cabal: Tests failed for test:bios-tests from hie-bios-0.7.1.
```