### PR TITLE
Remove CradleOpt type

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -1,6 +1,6 @@
 Cabal-Version:          2.2
 Name:                   hie-bios
-Version:                0.7.6
+Version:                0.8.0
 Author:                 Matthew Pickering <matthewtpickering@gmail.com>
 Maintainer:             Matthew Pickering <matthewtpickering@gmail.com>
 License:                BSD-3-Clause

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -5,7 +5,6 @@
 module HIE.Bios.Cradle (
       findCradle
     , loadCradle
-    , loadCustomCradle
     , loadImplicitCradle
     , yamlConfig
     , defaultCradle
@@ -75,9 +74,6 @@ findCradle wfile = do
 -- | Given root\/hie.yaml load the Cradle.
 loadCradle :: FilePath -> IO (Cradle Void)
 loadCradle = loadCradleWithOpts absurd
-
-loadCustomCradle :: Yaml.FromJSON b => (b -> Cradle a) -> FilePath -> IO (Cradle a)
-loadCustomCradle = loadCradleWithOpts
 
 -- | Given root\/foo\/bar.hs, load an implicit cradle
 loadImplicitCradle :: Show a => FilePath -> IO (Cradle a)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -74,10 +74,10 @@ findCradle wfile = do
 
 -- | Given root\/hie.yaml load the Cradle.
 loadCradle :: FilePath -> IO (Cradle Void)
-loadCradle = loadCradleWithOpts Types.defaultCradleOpts absurd
+loadCradle = loadCradleWithOpts absurd
 
 loadCustomCradle :: Yaml.FromJSON b => (b -> Cradle a) -> FilePath -> IO (Cradle a)
-loadCustomCradle = loadCradleWithOpts Types.defaultCradleOpts
+loadCustomCradle = loadCradleWithOpts
 
 -- | Given root\/foo\/bar.hs, load an implicit cradle
 loadImplicitCradle :: Show a => FilePath -> IO (Cradle a)
@@ -92,8 +92,8 @@ loadImplicitCradle wfile = do
 --   Find a cabal file by tracing ancestor directories.
 --   Find a sandbox according to a cabal sandbox config
 --   in a cabal directory.
-loadCradleWithOpts :: (Yaml.FromJSON b) => CradleOpts -> (b -> Cradle a) -> FilePath -> IO (Cradle a)
-loadCradleWithOpts _copts buildCustomCradle wfile = do
+loadCradleWithOpts :: (Yaml.FromJSON b) => (b -> Cradle a) -> FilePath -> IO (Cradle a)
+loadCradleWithOpts buildCustomCradle wfile = do
     cradleConfig <- readCradleConfig wfile
     return $ getCradle buildCustomCradle (cradleConfig, takeDirectory wfile)
 

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -8,19 +8,9 @@
 module HIE.Bios.Types where
 
 import           System.Exit
-import           System.IO
 import           Control.Exception              ( Exception )
 
 data BIOSVerbosity = Silent | Verbose
-
-data CradleOpts = CradleOpts
-                { cradleOptsVerbosity :: BIOSVerbosity
-                , cradleOptsHandle :: Maybe Handle
-                -- ^ The handle where to send output to, if not set, stderr.
-                }
-
-defaultCradleOpts :: CradleOpts
-defaultCradleOpts = CradleOpts Silent Nothing
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
I was reading through the code to try and understand it better and encountered this type that doesn't seem to be used by any of the functions that ask for it (they use an _ prefixed variable to discard it).

Can this type just be removed?