### PR TITLE
fix: rewrite findFileUpwards as a non predicate function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # ChangeLog hie-bios
 
+* Rename `findFileUpwards` as `findFileUpwardsPredicate` and implement
+  `findFileUpward` which does have better performance guarantees.
+
 ## 2025-04-25 - 0.15.0
 
 * Use consistent logging for test cases [#461](https://github.com/haskell/hie-bios/pull/461)


### PR DESCRIPTION
- `findFileUpwards` is renamed to `findFileUpwardsPredicate`.
- `findFileUpwards x dir` now behaves as `findFileUpwardsPredicate (x ==) dir` but can be dramatically faster.
- Rewrote all uses cases to use the `findFileUpwards` when the filename is already known.

The problem with the version with a predicate is that it needs to load all the files contained in each directories it traverses in order to apply the predicate. Even if these directories contains really few files, that's still slower than a direct test with `doesFileExists`.

But the situation can became really awful if the traversed directories contains a huge amount of file.

And huge can be any version of huge. For example, when working on the startup time of haskell-language-server on my work repository, see https://github.com/haskell/haskell-language-server/issues/4598 for the discussion, I observed that hls was spending 20s in `findFileUpwards`: hls was trying to locate the `hie.yaml` file starting from a repository which is stored in `/nix/store`, which contains hundreds of thousands of entries on my computer (and could actually be more).

This fix removes `20s` of the startup time of HLS on my work project and may do the same for anyone who have the chance of using HLS on a file which is stored in their `/nix/store`.

Note that unfortunately the cabal cradle still suffers from this issues.