### PR TITLE
Handle noisy stdout from cabal (e.g. darcs warnings)

### DIFF
--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -145,6 +145,11 @@ Extra-Source-Files:     README.md
                         tests/projects/failing-multi-repl-cabal-project/multi-repl-cabal-fail/src/Fail.hs
                         tests/projects/failing-multi-repl-cabal-project/multi-repl-cabal-fail/src/Lib.hs
                         tests/projects/failing-multi-repl-cabal-project/NotInPath.hs
+                        tests/projects/noisy-bios-ghc/A.hs
+                        tests/projects/noisy-bios-ghc/B.hs
+                        tests/projects/noisy-bios-ghc/hie-bios.sh
+                        tests/projects/noisy-bios-ghc/noisy-ghc.sh
+                        tests/projects/noisy-bios-ghc/hie.yaml
 
 tested-with: GHC ==9.6.7 || ==9.8.4 || ==9.10.1 || ==9.12.2 || ==9.14.1
 

--- a/src/HIE/Bios/Cradle/Cabal.hs
+++ b/src/HIE/Bios/Cradle/Cabal.hs
@@ -403,7 +403,7 @@ cabalProcess l vs cabalProject workDir command args = do
   ghcDirs@(ghcBin, libdir) <- callCabalPathForCompilerPath l vs workDir cabalProject >>= \case
     Just p -> do
       libdir <- Process.readProcessWithCwd_ l workDir p ["--print-libdir"] ""
-      pure (p, trimEnd libdir)
+      pure (p, trim libdir)
     Nothing -> cabalGhcDirs l cabalProject workDir
 
   ghcPkgPath <- liftIO $ withGhcPkgTool ghcBin libdir
@@ -464,7 +464,7 @@ cabalGhcDirs l cabalProject workDir = do
        ]
       )
       ""
-  pure (trimEnd exe, trimEnd libdir)
+  pure (trim exe, trim libdir)
   where
     projectFileArgs = projectFileProcessArgs cabalProject
 

--- a/src/HIE/Bios/Cradle/ProgramVersions.hs
+++ b/src/HIE/Bios/Cradle/ProgramVersions.hs
@@ -9,6 +9,7 @@ module HIE.Bios.Cradle.ProgramVersions
 
 import HIE.Bios.Types
 import qualified HIE.Bios.Process as Process
+import HIE.Bios.Cradle.Utils (trim)
 
 import Colog.Core (LogAction (..), WithSeverity (..))
 import Data.Version
@@ -67,6 +68,6 @@ getGhcVersion ghc = do
     _ -> pure Nothing
 
 versionMaybe :: String -> Maybe Version
-versionMaybe xs = case reverse $ readP_to_S parseVersion xs of
+versionMaybe xs = case reverse $ readP_to_S parseVersion (trim xs) of
   [] -> Nothing
   (x:_) -> Just (fst x)

--- a/src/HIE/Bios/Cradle/Utils.hs
+++ b/src/HIE/Bios/Cradle/Utils.hs
@@ -10,11 +10,14 @@ module HIE.Bios.Cradle.Utils
   , removeRTS
   , removeVerbosityOpts
   , expandGhcOptionResponseFile
+  -- * Processing of process output
+  , trim
   )
   where
 
 import HIE.Bios.Types (prettyCmdSpec)
 
+import Data.Char (isSpace)
 import Data.List
 import System.Process.Extra
 import GHC.ResponseFile (expandResponse)
@@ -105,4 +108,12 @@ expandGhcOptionResponseFile :: [String] -> IO [String]
 expandGhcOptionResponseFile args = do
   expanded_args <- expandResponse args
   pure $ removeInteractive expanded_args
+
+-- | Take the last line of output and strip trailing whitespace.
+-- This is necessary because some tools (e.g. darcs, 7zip via stack)
+-- produce extra output lines before the version number.
+trim :: String -> String
+trim s = case lines s of
+  [] -> s
+  ls -> dropWhileEnd isSpace $ last ls
 

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -15,11 +15,11 @@ import System.Environment (lookupEnv)
 import qualified Crypto.Hash.SHA1 as H
 import qualified Data.ByteString.Char8 as B
 import Data.ByteString.Base16
-import Data.List
 import Data.Char (isSpace)
 import Text.ParserCombinators.ReadP hiding (optional)
 
 import HIE.Bios.Types
+import HIE.Bios.Cradle.Utils (trim)
 import qualified HIE.Bios.Ghc.Gap as Gap
 import qualified System.OsPath as OsPath
 
@@ -245,10 +245,3 @@ value = many1 (satisfy (not . isSpace))
 anyToken :: ReadP Char
 anyToken = satisfy $ const True
 
--- Used for clipping the trailing newlines on GHC output
--- Also only take the last line of output
--- (Stack's ghc output has a lot of preceding noise from 7zip etc)
-trim :: String -> String
-trim s = case lines s of
-  [] -> s
-  ls -> dropWhileEnd isSpace $ last ls

--- a/tests/projects/noisy-bios-ghc/A.hs
+++ b/tests/projects/noisy-bios-ghc/A.hs
@@ -1,0 +1,1 @@
+module A where

--- a/tests/projects/noisy-bios-ghc/B.hs
+++ b/tests/projects/noisy-bios-ghc/B.hs
@@ -1,0 +1,3 @@
+module B where
+
+import A

--- a/tests/projects/noisy-bios-ghc/hie-bios.sh
+++ b/tests/projects/noisy-bios-ghc/hie-bios.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+echo "-Wall" >> $HIE_BIOS_OUTPUT
+echo "A" >> $HIE_BIOS_OUTPUT
+echo "B" >> $HIE_BIOS_OUTPUT

--- a/tests/projects/noisy-bios-ghc/hie.yaml
+++ b/tests/projects/noisy-bios-ghc/hie.yaml
@@ -1,0 +1,4 @@
+cradle:
+  bios:
+    program: ./hie-bios.sh
+    with-ghc: ./noisy-ghc.sh

--- a/tests/projects/noisy-bios-ghc/noisy-ghc.sh
+++ b/tests/projects/noisy-bios-ghc/noisy-ghc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Simulates the noise produced by tools like darcs, which output warnings
+# (e.g. "WARNING: creating a nested repository.") before the actual command
+# output when invoked inside a managed repository.
+echo "WARNING: creating a nested repository."
+exec ghc "$@"


### PR DESCRIPTION
Fixes #498.

When a cabal project has a `source-repository-package` with `type: darcs`, cabal triggers `darcs clone` during various operations. darcs likes to print `WARNING: creating a nested repository.` to stdout, and this noise ends up in the output of several commands that hie-bios runs and parses. The result is that HLS fails to start entirely in darcs-managed projects with darcs dependencies.

There were three places that needed fixing:

`versionMaybe` in ProgramVersions.hs was parsing the raw output of `--numeric-version` without stripping leading noise. The `trim` function (take the last line, strip trailing whitespace) already existed in Environment.hs for exactly this kind of problem; the comment even mentions Stack's 7zip noise. I moved `trim` to `Cradle.Utils` so both modules can use it.

`cabalGhcDirs` and `cabalProcess` in Cabal.hs were using `trimEnd` (strip trailing whitespace only) on the output of `cabal exec -- ghc --print-libdir` and `cabal exec -- ghc -e getExecutablePath`. This meant `HIE_BIOS_GHC` and `HIE_BIOS_GHC_ARGS` got the darcs warnings prepended to the actual paths. Changed these to use `trim` as well.

`callCabalPathForCompilerPath` parses JSON from `cabal path --output-format=json`, but the darcs warnings appear before the JSON object. I added a `dropWhile` to skip to the first `{` before parsing. Without this fix it technically still works (it falls back to the slower `cabal exec` path) but it does so on every single file load, making startup very slow.

Having to apply essentially the same fix in so many places feels like a code smell. There might be an opportunity to centralize the output cleanup closer to the process-running layer so that individual call sites don't each have to remember to strip noise.

I added an integration test for the `versionMaybe` path using a bios cradle with a noisy GHC wrapper script. The Cabal.hs fixes are harder to test without darcs in CI, but they use the same `trim` function. I tested the whole thing end-to-end against a real darcs project and HLS starts up and type-checks everything. Open to suggestions on better test coverage.