### PR TITLE
Make `cacheFile` thread-safe using file locks

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 * Make cacheFile thread-safe using file locks ([#520](https://github.com/haskell/hie-bios/pull/520)).
 * Make functions take the used cache directory explicitly ([#520](https://github.com/haskell/hie-bios/pull/520)).
   * Add *WithConfig functions.
-  * Adjust existing functions to take the cache directory.
+  * Adjust existing functions to take a cache directory.
   * Replace thread-unsafety workaround of initSession' and
     initSessionWithMessage' with the cache directory argument.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,7 @@
 # ChangeLog hie-bios
 
+## Unreleased
+
 ## 2026-06-30 - 0.20.0
 
 * Hide LoadMode in TestM ([#516](https://github.com/haskell/hie-bios/pull/516))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+* Make cacheFile thread-safe using file locks ([#520](https://github.com/haskell/hie-bios/pull/520)).
+* Make functions take the used cache directory explicitly ([#520](https://github.com/haskell/hie-bios/pull/520)).
+  * Add *WithConfig functions.
+  * Adjust existing functions to take the cache directory.
+  * Replace thread-unsafety workaround of initSession' and
+    initSessionWithMessage' with the cache directory argument.
+
 ## 2026-06-30 - 0.20.0
 
 * Hide LoadMode in TestM ([#516](https://github.com/haskell/hie-bios/pull/516))

--- a/hie-bios.cabal
+++ b/hie-bios.cabal
@@ -191,6 +191,7 @@ library
     exceptions ^>=0.10,
     extra >=1.6.14 && <1.9,
     file-embed >=0.0.11 && <1,
+    filelock >=0.1.1 && <0.2,
     filepath >=1.4.1 && <1.6,
     ghc >=9.2.1 && <10.2,
     prettyprinter ^>=1.6 || ^>=1.7.0,
@@ -242,6 +243,7 @@ test-suite bios-tests
   type: exitcode-stdio-1.0
   default-language: Haskell2010
   build-depends:
+    async,
     base,
     co-log-core,
     directory,

--- a/src/HIE/Bios.hs
+++ b/src/HIE/Bios.hs
@@ -14,7 +14,11 @@ module HIE.Bios (
   , CradleError(..)
   , findCradle
   , loadCradle
+  , loadCradleWithConfig
   , loadImplicitCradle
+  , loadImplicitCradleWithConfig
+  , CradleRunConfig(..)
+  , defaultCradleRunConfig
   , defaultCradle
   -- * Compiler Options
   , ComponentOptions(..)

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -133,7 +133,7 @@ addActionDeps deps =
       (\(ComponentOptions os' dir ds) -> CradleSuccess (ComponentOptions os' dir (ds `union` deps)))
 
 
-resolvedCradlesToCradle :: Show a => LogAction IO (WithSeverity Log) -> (b -> CradleAction a) -> FilePath -> FilePath -> [ResolvedCradle b] -> IO (Cradle a)
+resolvedCradlesToCradle :: Show a => LogAction IO (WithSeverity Log) -> (b -> CradleAction a) -> FilePath -> CacheDir -> [ResolvedCradle b] -> IO (Cradle a)
 resolvedCradlesToCradle logger buildCustomCradle root cacheDir cs = mdo
   let run_ghc_cmd args =
         -- We're being lazy here and just returning the ghc path for the

--- a/src/HIE/Bios/Cradle.hs
+++ b/src/HIE/Bios/Cradle.hs
@@ -7,7 +7,11 @@
 module HIE.Bios.Cradle (
       findCradle
     , loadCradle
+    , loadCradleWithConfig
     , loadImplicitCradle
+    , loadImplicitCradleWithConfig
+    , CradleRunConfig(..)
+    , defaultCradleRunConfig
     , yamlConfig
     , defaultCradle
     , isCabalCradle
@@ -19,6 +23,7 @@ module HIE.Bios.Cradle (
     , isDefaultCradle
     , isOtherCradle
     , getCradle
+    , getCradleWithConfig
     , Process.readProcessWithOutputs
     , Process.readProcessWithCwd
     , makeCradleResult
@@ -49,6 +54,7 @@ import System.IO (hClose, hPutStr)
 import System.IO.Temp
 
 import HIE.Bios.Config
+import HIE.Bios.Environment (resolveCacheDir)
 import HIE.Bios.Types hiding (ActionName(..))
 import qualified HIE.Bios.Process as Process
 import qualified HIE.Bios.Types as Types
@@ -77,32 +83,45 @@ findCradle wfile = do
 
 -- | Given root\/hie.yaml load the Cradle.
 loadCradle :: LogAction IO (WithSeverity Log) -> FilePath -> IO (Cradle Void)
-loadCradle l = loadCradleWithOpts l absurd
+loadCradle l = loadCradleWithConfig l defaultCradleRunConfig
+
+-- | 'loadCradle' with an explicit 'CradleRunConfig'.
+loadCradleWithConfig :: LogAction IO (WithSeverity Log) -> CradleRunConfig -> FilePath -> IO (Cradle Void)
+loadCradleWithConfig l config = loadCradleWithOpts l config absurd
 
 -- | Given root\/foo\/bar.hs, load an implicit cradle
 loadImplicitCradle :: Show a => LogAction IO (WithSeverity Log) -> FilePath -> IO (Cradle a)
-loadImplicitCradle l wfile = do
+loadImplicitCradle l = loadImplicitCradleWithConfig l defaultCradleRunConfig
+
+-- | 'loadImplicitCradle' with an explicit 'CradleRunConfig'.
+loadImplicitCradleWithConfig :: Show a => LogAction IO (WithSeverity Log) -> CradleRunConfig -> FilePath -> IO (Cradle a)
+loadImplicitCradleWithConfig l config wfile = do
   let wdir = takeDirectory wfile
   cfg <- runMaybeT (implicitConfig wdir)
   case cfg of
-    Just bc -> getCradle l absurd bc
+    Just bc -> getCradleWithConfig l config absurd bc
     Nothing -> return $ defaultCradle l wdir
 
 -- | Finding 'Cradle'.
 --   Find a cabal file by tracing ancestor directories.
 --   Find a sandbox according to a cabal sandbox config
 --   in a cabal directory.
-loadCradleWithOpts :: (Yaml.FromJSON b, Show a) => LogAction IO (WithSeverity Log) -> (b -> CradleAction a) -> FilePath -> IO (Cradle a)
-loadCradleWithOpts l buildCustomCradle wfile = do
+loadCradleWithOpts :: (Yaml.FromJSON b, Show a) => LogAction IO (WithSeverity Log) -> CradleRunConfig -> (b -> CradleAction a) -> FilePath -> IO (Cradle a)
+loadCradleWithOpts l config buildCustomCradle wfile = do
     cradleConfig <- readCradleConfig wfile
     l <& WithSeverity (LogAny $ T.pack $ "Cradle Config: " ++ show cradleConfig) Debug
-    getCradle l buildCustomCradle (cradleConfig, takeDirectory wfile)
+    getCradleWithConfig l config buildCustomCradle (cradleConfig, takeDirectory wfile)
 
 getCradle :: Show a => LogAction IO (WithSeverity Log) ->  (b -> CradleAction a) -> (CradleConfig b, FilePath) -> IO (Cradle a)
-getCradle l buildCustomCradle (cc, wdir) = do
+getCradle l = getCradleWithConfig l defaultCradleRunConfig
+
+-- | 'getCradle' with an explicit 'CradleRunConfig'.
+getCradleWithConfig :: Show a => LogAction IO (WithSeverity Log) -> CradleRunConfig -> (b -> CradleAction a) -> (CradleConfig b, FilePath) -> IO (Cradle a)
+getCradleWithConfig l config buildCustomCradle (cc, wdir) = do
     rcs <- canonicalizeResolvedCradles wdir cs
     liftIO $ l <& WithSeverity (LogAny . T.pack $ "Resolved Cradles " ++ show ((fmap . fmap) (const ()) rcs)) Debug
-    resolvedCradlesToCradle l buildCustomCradle wdir rcs
+    cacheDir <- resolveCacheDir "" (cradleCacheDir config)
+    resolvedCradlesToCradle l buildCustomCradle wdir cacheDir rcs
   where
     cs = resolveCradleTree wdir cc
 
@@ -114,8 +133,8 @@ addActionDeps deps =
       (\(ComponentOptions os' dir ds) -> CradleSuccess (ComponentOptions os' dir (ds `union` deps)))
 
 
-resolvedCradlesToCradle :: Show a => LogAction IO (WithSeverity Log) -> (b -> CradleAction a) -> FilePath -> [ResolvedCradle b] -> IO (Cradle a)
-resolvedCradlesToCradle logger buildCustomCradle root cs = mdo
+resolvedCradlesToCradle :: Show a => LogAction IO (WithSeverity Log) -> (b -> CradleAction a) -> FilePath -> FilePath -> [ResolvedCradle b] -> IO (Cradle a)
+resolvedCradlesToCradle logger buildCustomCradle root cacheDir cs = mdo
   let run_ghc_cmd args =
         -- We're being lazy here and just returning the ghc path for the
         -- first non-none cradle. This shouldn't matter in practice: all
@@ -127,7 +146,7 @@ resolvedCradlesToCradle logger buildCustomCradle root cs = mdo
               act
               args
   versions <- makeVersions logger root run_ghc_cmd
-  let rcs = ResolvedCradles root cs versions
+  let rcs = ResolvedCradles root cs versions cacheDir
       cradleActions = [ (c, resolveCradleAction logger buildCustomCradle rcs root c) | c <- cs ]
       err_msg (TargetWithContext fp fps)
         = ["Multi Cradle: No prefixes matched"
@@ -563,7 +582,7 @@ stackAction workDir mc syaml l cs fpc loadStyle = do
   logCradleHasNoSupportForLoadFileWithContext l loadStyle "stack"
   let ghcProc args = proc "stack" (stackYamlProcessArgs syaml <> ["exec", "ghc", "--"] <> args)
   -- Same wrapper works as with cabal
-  wrapper_fp <- withGhcWrapperTool l ghcProc workDir
+  wrapper_fp <- withGhcWrapperTool l (cradleCacheDirResolved cs) ghcProc workDir
   let
     fallback = [ comp | Just comp <- [mc] ]
     componentsToLoad = nubOrd <$> mconcat

--- a/src/HIE/Bios/Cradle/Cabal.hs
+++ b/src/HIE/Bios/Cradle/Cabal.hs
@@ -40,7 +40,6 @@ import System.IO.Temp
 import Data.Version
 
 import HIE.Bios.Config
-import HIE.Bios.Environment (getCacheDir)
 import HIE.Bios.Types hiding (ActionName(..))
 import HIE.Bios.Wrappers
 import qualified HIE.Bios.Process as Process
@@ -162,11 +161,12 @@ cabalAction cradles workDir mc l projectFile fp loadStyle = do
 
   cabalFeatures <- determineCabalLoadFeature progVersions
   let
+    cacheDir = cradleCacheDirResolved cradles
     -- Used for @cabal >= 3.15@ but @lib:Cabal <3.15@, in custom setups.
-    mkFallbackCabalProc = cabalLoadFilesBefore315 l progVersions projectFile workDir cabalArgs
+    mkFallbackCabalProc = cabalLoadFilesBefore315 l cacheDir progVersions projectFile workDir cabalArgs
   cabalProc <- case cabalFeatures of
-    CabalWithRepl -> cabalLoadFilesWithRepl l projectFile workDir cabalArgs
-    CabalWithGhcShimWrapper -> cabalLoadFilesBefore315 l progVersions projectFile workDir cabalArgs
+    CabalWithRepl -> cabalLoadFilesWithRepl l cacheDir projectFile workDir cabalArgs
+    CabalWithGhcShimWrapper -> cabalLoadFilesBefore315 l cacheDir progVersions projectFile workDir cabalArgs
 
   mResult <- runCabalToGetGhcOptions cabalProc mkFallbackCabalProc
   case mResult of
@@ -246,15 +246,15 @@ cabalAction cradles workDir mc l projectFile fp loadStyle = do
 runCabalGhcCmd :: ResolvedCradles a -> FilePath -> LogAction IO (WithSeverity Log) -> CradleProjectConfig -> [String] -> IO (CradleLoadResult String)
 runCabalGhcCmd cs wdir l projectFile args = runCradleResultT $ do
   let vs = cradleProgramVersions cs
-  callCabalPathForCompilerPath l vs wdir projectFile >>= \case
+  callCabalPathForCompilerPath l (cradleCacheDirResolved cs) vs wdir projectFile >>= \case
     Just p -> Process.readProcessWithCwd_ l wdir p args ""
     Nothing -> do
-      buildDir <- liftIO $ cabalBuildDir wdir
+      buildDir <- liftIO $ cabalBuildDir (cradleCacheDirResolved cs) wdir
       -- Workaround for a cabal-install bug on 3.0.0.0:
       -- ./dist-newstyle/tmp/environment.-24811: createDirectory: does not exist (No such file or directory)
       liftIO $ createDirectoryIfMissing True (buildDir </> "tmp")
       -- Need to pass -v0 otherwise we get "resolving dependencies..."
-      cabalProc <- cabalExecGhc l vs projectFile wdir args
+      cabalProc <- cabalExecGhc l (cradleCacheDirResolved cs) vs projectFile wdir args
       Process.readProcessWithCwd' l cabalProc ""
 
 data LoadUnits = Inferred | FromCradle
@@ -357,11 +357,11 @@ processCabalLoadMode l cradles projectFile workDir mc fpc loadStyle = do
             (FromCradle,units) -> units
       pure (["--enable-multi-repl"] ++ compArgs ++ allModules, allFiles, mergedDeps)
 
-cabalLoadFilesWithRepl :: LogAction IO (WithSeverity Log) -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
-cabalLoadFilesWithRepl l projectFile workDir args = do
-  buildDir <- liftIO $ cabalBuildDir workDir
+cabalLoadFilesWithRepl :: LogAction IO (WithSeverity Log) -> FilePath -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
+cabalLoadFilesWithRepl l cacheDir projectFile workDir args = do
+  buildDir <- liftIO $ cabalBuildDir cacheDir workDir
   newEnvironment <- liftIO Process.getCleanEnvironment
-  wrapper_fp <- liftIO $ withReplWrapperTool l (proc "ghc") workDir
+  wrapper_fp <- liftIO $ withReplWrapperTool l cacheDir (proc "ghc") workDir
   let
     cabalCommand = "v2-repl"
     cabalArgs =
@@ -447,15 +447,15 @@ processCabalWrapperArgs args =
 -- them.
 -- ----------------------------------------------------------------------------
 
-cabalLoadFilesBefore315 :: LogAction IO (WithSeverity Log) -> ProgramVersions -> CradleProjectConfig -> [Char] -> [String] -> CradleLoadResultT IO CreateProcess
-cabalLoadFilesBefore315 l progVersions projectFile workDir args' = do
+cabalLoadFilesBefore315 :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> [Char] -> [String] -> CradleLoadResultT IO CreateProcess
+cabalLoadFilesBefore315 l cacheDir progVersions projectFile workDir args' = do
   let cabalCommand = "v2-repl"
   cabal_version <- liftIO $ runCachedIO $ cabalVersion progVersions
 
   let args = case cabal_version of
         Just v | v < makeVersion [3,15] -> "--keep-temp-files" : args'
         _ -> args'
-  cabalProcess l progVersions projectFile workDir cabalCommand args `modCradleError` \err -> do
+  cabalProcess l cacheDir progVersions projectFile workDir cabalCommand args `modCradleError` \err -> do
     deps <- cabalCradleDependencies projectFile workDir workDir
     pure $ err {cradleErrorDependencies = cradleErrorDependencies err ++ deps}
 
@@ -468,15 +468,15 @@ cabalLoadFilesBefore315 l progVersions projectFile workDir args' = do
 -- to the custom ghc wrapper via 'hie_bios_ghc' environment variable which
 -- the custom ghc wrapper may use as a fallback if it can not respond to certain
 -- queries, such as ghc version or location of the libdir.
-cabalProcess :: LogAction IO (WithSeverity Log) -> ProgramVersions -> CradleProjectConfig -> FilePath -> String -> [String] -> CradleLoadResultT IO CreateProcess
-cabalProcess l vs cabalProject workDir command args = do
-  ghcDirs@(ghcBin, libdir) <- callCabalPathForCompilerPath l vs workDir cabalProject >>= \case
+cabalProcess :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> FilePath -> String -> [String] -> CradleLoadResultT IO CreateProcess
+cabalProcess l cacheDir vs cabalProject workDir command args = do
+  ghcDirs@(ghcBin, libdir) <- callCabalPathForCompilerPath l cacheDir vs workDir cabalProject >>= \case
     Just p -> do
       libdir <- Process.readProcessWithCwd_ l workDir p ["--print-libdir"] ""
       pure (p, trimEnd libdir)
     Nothing -> cabalGhcDirs l cabalProject workDir
 
-  ghcPkgPath <- liftIO $ withGhcPkgTool ghcBin libdir
+  ghcPkgPath <- liftIO $ withGhcPkgTool cacheDir ghcBin libdir
   newEnvironment <- liftIO $ setupEnvironment ghcDirs
   cabalProc <- liftIO $ setupCabalCommand ghcPkgPath
   pure $ (cabalProc
@@ -495,8 +495,8 @@ cabalProcess l vs cabalProject workDir command args = do
 
     setupCabalCommand :: FilePath -> IO CreateProcess
     setupCabalCommand ghcPkgPath = do
-      wrapper_fp <- withGhcWrapperTool l (proc "ghc") workDir
-      buildDir <- cabalBuildDir workDir
+      wrapper_fp <- withGhcWrapperTool l cacheDir (proc "ghc") workDir
+      buildDir <- cabalBuildDir cacheDir workDir
       let extraCabalArgs =
             [ "--builddir=" <> buildDir
             , command
@@ -555,8 +555,8 @@ cabalGhcDirs l cabalProject workDir = do
 --
 -- Here, we restore the wrapper-shims, if necessary, thus the returned filepath
 -- can be passed to 'cabal' without further modifications.
-withGhcPkgTool :: FilePath -> FilePath -> IO FilePath
-withGhcPkgTool ghcPathAbs libdir = do
+withGhcPkgTool :: FilePath -> FilePath -> FilePath -> IO FilePath
+withGhcPkgTool cacheDir ghcPathAbs libdir = do
   let ghcName = takeFileName ghcPathAbs
       -- TODO: check for existence
       ghcPkgPath = guessGhcPkgFromGhc ghcName
@@ -592,7 +592,7 @@ withGhcPkgTool ghcPathAbs libdir = do
                       ]
             ]
           srcHash = show (fingerprintString contents)
-      cacheFile "ghc-pkg" srcHash $ \wrapperFp -> writeFile wrapperFp contents
+      cacheFileIn cacheDir "ghc-pkg" srcHash $ \wrapperFp -> writeFile wrapperFp contents
 
     -- Escape the filepath and trim excess newlines added by 'escapeArgs'
     escapeFilePath fp = trimEnd $ escapeArgs [fp]
@@ -607,9 +607,9 @@ type GhcProc = [String] -> CreateProcess
 -- | Generate a fake GHC that can be passed to cabal or stack
 -- when run with --interactive, it will print out its
 -- command-line arguments and exit
-withGhcWrapperTool :: LogAction IO (WithSeverity Log) -> GhcProc -> FilePath -> IO FilePath
-withGhcWrapperTool l mkGhcCall wdir = do
-  withWrapperTool l mkGhcCall wdir "wrapper" cabalWrapperHs cabalWrapper
+withGhcWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> FilePath -> IO FilePath
+withGhcWrapperTool l cacheDir mkGhcCall wdir = do
+  withWrapperTool l cacheDir mkGhcCall wdir "wrapper" cabalWrapperHs cabalWrapper
 
 -- | Generate a script/binary that can be passed to cabal's '--with-repl'.
 -- On windows, this compiles a Haskell file, while on other systems, we persist
@@ -617,16 +617,16 @@ withGhcWrapperTool l mkGhcCall wdir = do
 --
 -- 'GhcProc' is unused on other platforms.
 --
-withReplWrapperTool :: LogAction IO (WithSeverity Log) -> GhcProc -> FilePath -> IO FilePath
-withReplWrapperTool l mkGhcCall wdir =
-  withWrapperTool l mkGhcCall wdir "repl-wrapper" cabalWithReplWrapperHs cabalWithReplWrapper
+withReplWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> FilePath -> IO FilePath
+withReplWrapperTool l cacheDir mkGhcCall wdir =
+  withWrapperTool l cacheDir mkGhcCall wdir "repl-wrapper" cabalWithReplWrapperHs cabalWithReplWrapper
 
-withWrapperTool :: LogAction IO (WithSeverity Log) -> GhcProc -> String -> FilePath -> String -> String -> IO FilePath
-withWrapperTool l mkGhcCall wdir baseName windowsWrapper unixWrapper = do
+withWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> String -> FilePath -> String -> String -> IO FilePath
+withWrapperTool l cacheDir mkGhcCall wdir baseName windowsWrapper unixWrapper = do
   let wrapperContents = if isWindows then windowsWrapper else unixWrapper
       withExtension fp = if isWindows then fp <.> "exe" else fp
       srcHash = show (fingerprintString wrapperContents)
-  cacheFile (withExtension baseName) srcHash $ \wrapper_fp ->
+  cacheFileIn cacheDir (withExtension baseName) srcHash $ \wrapper_fp ->
     if isWindows
     then
       withSystemTempDirectory "hie-bios" $ \ tmpDir -> do
@@ -657,13 +657,13 @@ projectLocationOrDefault = \case
 -- cabal locations
 -- ----------------------------------------------------------------------------
 
--- | Given the root directory, get the build dir we are using for cabal
--- In the `hie-bios` cache directory
-cabalBuildDir :: FilePath -> IO FilePath
-cabalBuildDir workDir = do
+-- | Given the cache root and the work directory, get the build dir we are
+-- using for cabal.
+cabalBuildDir :: FilePath -> FilePath -> IO FilePath
+cabalBuildDir cacheDir workDir = do
   abs_work_dir <- makeAbsolute workDir
   let dirHash = show (fingerprintString abs_work_dir)
-  getCacheDir ("dist-" <> filter (not . isSpace) (takeBaseName abs_work_dir)<>"-"<>dirHash)
+  pure $ cacheDir </> ("dist-" <> filter (not . isSpace) (takeBaseName abs_work_dir)<>"-"<>dirHash)
 
 -- |Find .cabal files in the given directory.
 --
@@ -678,16 +678,16 @@ findCabalFiles wdir = do
 -- cabal process wrappers and helpers
 -- ----------------------------------------------------------------------------
 
-cabalExecGhc :: LogAction IO (WithSeverity Log) -> ProgramVersions -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
-cabalExecGhc l vs projectFile wdir args = do
-  cabalProcess l vs projectFile wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
+cabalExecGhc :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
+cabalExecGhc l cacheDir vs projectFile wdir args = do
+  cabalProcess l cacheDir vs projectFile wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
 
-callCabalPathForCompilerPath :: LogAction IO (WithSeverity Log) -> ProgramVersions -> FilePath -> CradleProjectConfig -> CradleLoadResultT IO (Maybe FilePath)
-callCabalPathForCompilerPath l vs workDir projectFile = do
+callCabalPathForCompilerPath :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> FilePath -> CradleProjectConfig -> CradleLoadResultT IO (Maybe FilePath)
+callCabalPathForCompilerPath l cacheDir vs workDir projectFile = do
   isCabalPathSupported vs >>= \case
     False -> pure Nothing
     True -> do
-      buildDir <- liftIO $ cabalBuildDir workDir
+      buildDir <- liftIO $ cabalBuildDir cacheDir workDir
       let
         args = [ "--builddir=" <> buildDir, "path", "--output-format=json" ]
             <> projectFileProcessArgs projectFile

--- a/src/HIE/Bios/Cradle/Cabal.hs
+++ b/src/HIE/Bios/Cradle/Cabal.hs
@@ -357,7 +357,7 @@ processCabalLoadMode l cradles projectFile workDir mc fpc loadStyle = do
             (FromCradle,units) -> units
       pure (["--enable-multi-repl"] ++ compArgs ++ allModules, allFiles, mergedDeps)
 
-cabalLoadFilesWithRepl :: LogAction IO (WithSeverity Log) -> FilePath -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
+cabalLoadFilesWithRepl :: LogAction IO (WithSeverity Log) -> CacheDir -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
 cabalLoadFilesWithRepl l cacheDir projectFile workDir args = do
   buildDir <- liftIO $ cabalBuildDir cacheDir workDir
   newEnvironment <- liftIO Process.getCleanEnvironment
@@ -447,7 +447,7 @@ processCabalWrapperArgs args =
 -- them.
 -- ----------------------------------------------------------------------------
 
-cabalLoadFilesBefore315 :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> [Char] -> [String] -> CradleLoadResultT IO CreateProcess
+cabalLoadFilesBefore315 :: LogAction IO (WithSeverity Log) -> CacheDir -> ProgramVersions -> CradleProjectConfig -> [Char] -> [String] -> CradleLoadResultT IO CreateProcess
 cabalLoadFilesBefore315 l cacheDir progVersions projectFile workDir args' = do
   let cabalCommand = "v2-repl"
   cabal_version <- liftIO $ runCachedIO $ cabalVersion progVersions
@@ -468,7 +468,7 @@ cabalLoadFilesBefore315 l cacheDir progVersions projectFile workDir args' = do
 -- to the custom ghc wrapper via 'hie_bios_ghc' environment variable which
 -- the custom ghc wrapper may use as a fallback if it can not respond to certain
 -- queries, such as ghc version or location of the libdir.
-cabalProcess :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> FilePath -> String -> [String] -> CradleLoadResultT IO CreateProcess
+cabalProcess :: LogAction IO (WithSeverity Log) -> CacheDir -> ProgramVersions -> CradleProjectConfig -> FilePath -> String -> [String] -> CradleLoadResultT IO CreateProcess
 cabalProcess l cacheDir vs cabalProject workDir command args = do
   ghcDirs@(ghcBin, libdir) <- callCabalPathForCompilerPath l cacheDir vs workDir cabalProject >>= \case
     Just p -> do
@@ -555,7 +555,7 @@ cabalGhcDirs l cabalProject workDir = do
 --
 -- Here, we restore the wrapper-shims, if necessary, thus the returned filepath
 -- can be passed to 'cabal' without further modifications.
-withGhcPkgTool :: FilePath -> FilePath -> FilePath -> IO FilePath
+withGhcPkgTool :: CacheDir -> FilePath -> FilePath -> IO FilePath
 withGhcPkgTool cacheDir ghcPathAbs libdir = do
   let ghcName = takeFileName ghcPathAbs
       -- TODO: check for existence
@@ -607,7 +607,7 @@ type GhcProc = [String] -> CreateProcess
 -- | Generate a fake GHC that can be passed to cabal or stack
 -- when run with --interactive, it will print out its
 -- command-line arguments and exit
-withGhcWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> FilePath -> IO FilePath
+withGhcWrapperTool :: LogAction IO (WithSeverity Log) -> CacheDir -> GhcProc -> FilePath -> IO FilePath
 withGhcWrapperTool l cacheDir mkGhcCall wdir = do
   withWrapperTool l cacheDir mkGhcCall wdir "wrapper" cabalWrapperHs cabalWrapper
 
@@ -617,11 +617,11 @@ withGhcWrapperTool l cacheDir mkGhcCall wdir = do
 --
 -- 'GhcProc' is unused on other platforms.
 --
-withReplWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> FilePath -> IO FilePath
+withReplWrapperTool :: LogAction IO (WithSeverity Log) -> CacheDir -> GhcProc -> FilePath -> IO FilePath
 withReplWrapperTool l cacheDir mkGhcCall wdir =
   withWrapperTool l cacheDir mkGhcCall wdir "repl-wrapper" cabalWithReplWrapperHs cabalWithReplWrapper
 
-withWrapperTool :: LogAction IO (WithSeverity Log) -> FilePath -> GhcProc -> String -> FilePath -> String -> String -> IO FilePath
+withWrapperTool :: LogAction IO (WithSeverity Log) -> CacheDir -> GhcProc -> String -> FilePath -> String -> String -> IO FilePath
 withWrapperTool l cacheDir mkGhcCall wdir baseName windowsWrapper unixWrapper = do
   let wrapperContents = if isWindows then windowsWrapper else unixWrapper
       withExtension fp = if isWindows then fp <.> "exe" else fp
@@ -659,8 +659,8 @@ projectLocationOrDefault = \case
 
 -- | Given the cache root and the work directory, get the build dir we are
 -- using for cabal.
-cabalBuildDir :: FilePath -> FilePath -> IO FilePath
-cabalBuildDir cacheDir workDir = do
+cabalBuildDir :: CacheDir -> FilePath -> IO FilePath
+cabalBuildDir (CacheDir cacheDir) workDir = do
   abs_work_dir <- makeAbsolute workDir
   let dirHash = show (fingerprintString abs_work_dir)
   pure $ cacheDir </> ("dist-" <> filter (not . isSpace) (takeBaseName abs_work_dir)<>"-"<>dirHash)
@@ -678,11 +678,11 @@ findCabalFiles wdir = do
 -- cabal process wrappers and helpers
 -- ----------------------------------------------------------------------------
 
-cabalExecGhc :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
+cabalExecGhc :: LogAction IO (WithSeverity Log) -> CacheDir -> ProgramVersions -> CradleProjectConfig -> FilePath -> [String] -> CradleLoadResultT IO CreateProcess
 cabalExecGhc l cacheDir vs projectFile wdir args = do
   cabalProcess l cacheDir vs projectFile wdir "v2-exec" $ ["ghc", "-v0", "--"] ++ args
 
-callCabalPathForCompilerPath :: LogAction IO (WithSeverity Log) -> FilePath -> ProgramVersions -> FilePath -> CradleProjectConfig -> CradleLoadResultT IO (Maybe FilePath)
+callCabalPathForCompilerPath :: LogAction IO (WithSeverity Log) -> CacheDir -> ProgramVersions -> FilePath -> CradleProjectConfig -> CradleLoadResultT IO (Maybe FilePath)
 callCabalPathForCompilerPath l cacheDir vs workDir projectFile = do
   isCabalPathSupported vs >>= \case
     False -> pure Nothing

--- a/src/HIE/Bios/Cradle/Resolved.hs
+++ b/src/HIE/Bios/Cradle/Resolved.hs
@@ -14,6 +14,7 @@ data ResolvedCradles a = ResolvedCradles
  { cradleRoot :: FilePath
  , resolvedCradles :: [ResolvedCradle a] -- ^ In order of decreasing specificity
  , cradleProgramVersions :: ProgramVersions
+ , cradleCacheDirResolved :: FilePath
  }
 
 -- | 'ConcreteCradle' augmented with information on which file the

--- a/src/HIE/Bios/Cradle/Resolved.hs
+++ b/src/HIE/Bios/Cradle/Resolved.hs
@@ -7,6 +7,7 @@ module HIE.Bios.Cradle.Resolved
 
 import HIE.Bios.Cradle.ProgramVersions
 import HIE.Bios.Config
+import HIE.Bios.Types
 
 -- | The final cradle config that specifies the cradle for
 -- each prefix we know how to handle
@@ -14,7 +15,7 @@ data ResolvedCradles a = ResolvedCradles
  { cradleRoot :: FilePath
  , resolvedCradles :: [ResolvedCradle a] -- ^ In order of decreasing specificity
  , cradleProgramVersions :: ProgramVersions
- , cradleCacheDirResolved :: FilePath
+ , cradleCacheDirResolved :: CacheDir
  }
 
 -- | 'ConcreteCradle' augmented with information on which file the

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -42,7 +42,7 @@ initSession = initSession' Nothing
 -- | 'initSession' with caches placed under the given root instead of resolved
 -- from the environment.
 initSession' :: (GhcMonad m)
-    => Maybe FilePath
+    => Maybe CacheDir
     -> ComponentOptions
     -> m [G.Target]
 initSession' mCacheRoot ComponentOptions {..} = do
@@ -166,18 +166,21 @@ however, it's not really necessary as
 -- | Prepends the cache directory used by the library to the supplied file path.
 -- It tries to use the path under the environment variable `$HIE_BIOS_CACHE_DIR`
 -- and falls back to the standard `$XDG_CACHE_HOME/hie-bios` if the former is not set
-getCacheDir :: FilePath -> IO FilePath
+getCacheDir :: FilePath -> IO CacheDir
 getCacheDir fp = do
   mbEnvCacheDirectory <- lookupEnv "HIE_BIOS_CACHE_DIR"
   cacheBaseDir <- maybe (getXdgDirectory XdgCache cacheDir) return
                          mbEnvCacheDirectory
-  return (cacheBaseDir </> fp)
+  return (CacheDir (cacheBaseDir </> fp))
 
 -- | Resolve a cache directory root, appending @suffix@ and making it absolute.
 -- An explicit path is used as given. 'Nothing' falls back to 'getCacheDir'.
-resolveCacheDir :: FilePath -> Maybe FilePath -> IO FilePath
-resolveCacheDir suffix mCacheRoot =
-  makeAbsolute =<< maybe (getCacheDir suffix) (pure . (</> suffix)) mCacheRoot
+resolveCacheDir :: FilePath -> Maybe CacheDir -> IO CacheDir
+resolveCacheDir suffix mCacheRoot = do
+  resolved <- case mCacheRoot of
+    Nothing -> fmap unCacheDir (getCacheDir suffix)
+    Just cacheRoot -> pure ((</> suffix) (unCacheDir cacheRoot))
+  fmap CacheDir (makeAbsolute resolved)
 
 ----------------------------------------------------------------
 
@@ -196,9 +199,9 @@ setIgnoreInterfacePragmas df = Gap.gopt_set df G.Opt_IgnoreInterfacePragmas
 setVerbosity :: Int -> G.DynFlags -> G.DynFlags
 setVerbosity n df = df { G.verbosity = n }
 
-writeInterfaceFiles :: Maybe FilePath -> G.DynFlags -> G.DynFlags
+writeInterfaceFiles :: Maybe CacheDir -> G.DynFlags -> G.DynFlags
 writeInterfaceFiles Nothing df = df
-writeInterfaceFiles (Just hi_dir) df = setHiDir hi_dir (Gap.gopt_set df G.Opt_WriteInterface)
+writeInterfaceFiles (Just (CacheDir hi_dir)) df = setHiDir hi_dir (Gap.gopt_set df G.Opt_WriteInterface)
 
 setHiDir :: FilePath -> G.DynFlags -> G.DynFlags
 setHiDir f d = d { G.hiDir      = Just f}

--- a/src/HIE/Bios/Environment.hs
+++ b/src/HIE/Bios/Environment.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE RecordWildCards, CPP #-}
 {-# LANGUAGE TupleSections #-}
-module HIE.Bios.Environment (initSession, initSession', getRuntimeGhcLibDir, getRuntimeGhcVersion, makeDynFlagsAbsolute, makeTargetsAbsolute, getCacheDir, addCmdOpts, extractUnits) where
+module HIE.Bios.Environment (initSession, initSession', getRuntimeGhcLibDir, getRuntimeGhcVersion, makeDynFlagsAbsolute, makeTargetsAbsolute, getCacheDir, resolveCacheDir, addCmdOpts, extractUnits) where
 
 import GHC (GhcMonad)
 import qualified GHC as G
@@ -37,21 +37,20 @@ import Data.Maybe (fromMaybe)
 initSession :: (GhcMonad m)
     => ComponentOptions
     -> m [G.Target]
-initSession = initSession' False
+initSession = initSession' Nothing
 
+-- | 'initSession' with caches placed under the given root instead of resolved
+-- from the environment.
 initSession' :: (GhcMonad m)
-    => Bool
+    => Maybe FilePath
     -> ComponentOptions
     -> m [G.Target]
-initSession' workAroundThreadUnsafety ComponentOptions {..} = do
+initSession' mCacheRoot ComponentOptions {..} = do
     -- Create a unique folder per set of different GHC options, assuming that each different set of
     -- GHC options will create incompatible interface files.
-    let
-      -- There seems to be a race condition when writing interface files
-      hash_args = (if workAroundThreadUnsafety then (componentRoot :) else id) componentOptions
-      opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init $ map B.pack hash_args
+    let opts_hash = B.unpack $ encode $ H.finalize $ H.updates H.init $ map B.pack componentOptions
 
-    cache_dir <- liftIO $ makeAbsolute =<< getCacheDir opts_hash
+    cache_dir <- liftIO $ resolveCacheDir opts_hash mCacheRoot
 
     -- Plan:
     -- - Extract `-unit @resp_file` options if present
@@ -173,6 +172,12 @@ getCacheDir fp = do
   cacheBaseDir <- maybe (getXdgDirectory XdgCache cacheDir) return
                          mbEnvCacheDirectory
   return (cacheBaseDir </> fp)
+
+-- | Resolve a cache directory root, appending @suffix@ and making it absolute.
+-- An explicit path is used as given. 'Nothing' falls back to 'getCacheDir'.
+resolveCacheDir :: FilePath -> Maybe FilePath -> IO FilePath
+resolveCacheDir suffix mCacheRoot =
+  makeAbsolute =<< maybe (getCacheDir suffix) (pure . (</> suffix)) mCacheRoot
 
 ----------------------------------------------------------------
 

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -49,15 +49,17 @@ initSessionWithMessage :: (GhcMonad m)
             => Maybe G.Messager
             -> ComponentOptions
             -> (m G.SuccessFlag, ComponentOptions)
-initSessionWithMessage = initSessionWithMessage' False
+initSessionWithMessage = initSessionWithMessage' Nothing
 
+-- | 'initSessionWithMessage' with the interface-file cache placed under the
+-- given root, see 'initSession''.
 initSessionWithMessage' :: (GhcMonad m)
-            => Bool
+            => Maybe FilePath
             -> Maybe G.Messager
             -> ComponentOptions
             -> (m G.SuccessFlag, ComponentOptions)
-initSessionWithMessage' workAroundThreadUnsafety msg compOpts = (do
-    targets <- initSession' workAroundThreadUnsafety compOpts
+initSessionWithMessage' mCacheRoot msg compOpts = (do
+    targets <- initSession' mCacheRoot compOpts
     G.setTargets targets
     -- Get the module graph using the function `getModuleGraph`
     mod_graph <- G.depanal [] True

--- a/src/HIE/Bios/Ghc/Api.hs
+++ b/src/HIE/Bios/Ghc/Api.hs
@@ -54,7 +54,7 @@ initSessionWithMessage = initSessionWithMessage' Nothing
 -- | 'initSessionWithMessage' with the interface-file cache placed under the
 -- given root, see 'initSession''.
 initSessionWithMessage' :: (GhcMonad m)
-            => Maybe FilePath
+            => Maybe CacheDir
             -> Maybe G.Messager
             -> ComponentOptions
             -> (m G.SuccessFlag, ComponentOptions)

--- a/src/HIE/Bios/Process.hs
+++ b/src/HIE/Bios/Process.hs
@@ -162,8 +162,8 @@ cacheFile fpName srcHash populate = do
 
 -- | 'cacheFile' with the cache directory given explicitly instead of resolved
 -- from the environment.
-cacheFileIn :: FilePath -> FilePath -> String -> (FilePath -> IO ()) -> IO FilePath
-cacheFileIn cacheDir fpName srcHash populate = do
+cacheFileIn :: CacheDir -> FilePath -> String -> (FilePath -> IO ()) -> IO FilePath
+cacheFileIn (CacheDir cacheDir) fpName srcHash populate = do
   createDirectoryIfMissing True cacheDir
   let newFpName = cacheDir </> (dropExtensions fpName <> "-" <> srcHash) <.> takeExtensions fpName
   -- Concurrent loads race to create the same cache entry, so serialize them on

--- a/src/HIE/Bios/Process.hs
+++ b/src/HIE/Bios/Process.hs
@@ -11,6 +11,7 @@ module HIE.Bios.Process
   , getCleanEnvironment
   -- * File Caching
   , cacheFile
+  , cacheFileIn
   -- * Find file utilities
   , findFileUpwards
   , findFileUpwardsPredicate
@@ -36,6 +37,7 @@ import qualified Data.HashMap.Strict as Map
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import System.Environment
+import System.FileLock
 import System.FilePath
 import System.IO (hClose, hGetContents, hSetBuffering, BufferMode(LineBuffering), withFile, IOMode(..))
 import System.IO.Error (isPermissionError)
@@ -156,14 +158,24 @@ readProcessWithOutputs outputNames l workDir cp = flip runContT return $ do
 cacheFile :: FilePath -> String -> (FilePath -> IO ()) -> IO FilePath
 cacheFile fpName srcHash populate = do
   cacheDir <- getCacheDir ""
+  cacheFileIn cacheDir fpName srcHash populate
+
+-- | 'cacheFile' with the cache directory given explicitly instead of resolved
+-- from the environment.
+cacheFileIn :: FilePath -> FilePath -> String -> (FilePath -> IO ()) -> IO FilePath
+cacheFileIn cacheDir fpName srcHash populate = do
   createDirectoryIfMissing True cacheDir
   let newFpName = cacheDir </> (dropExtensions fpName <> "-" <> srcHash) <.> takeExtensions fpName
-  unlessM (doesFileExist newFpName) $ do
-    populate newFpName
-    setMode newFpName
+  -- Concurrent loads race to create the same cache entry, so serialize them on
+  -- a lock. Populate into a temp file and rename to keep it atomic as well.
+  withFileLock (newFpName <.> "lock") Exclusive $ \_ ->
+    unlessM (doesFileExist newFpName) $
+      withTempFile cacheDir (takeFileName newFpName) $ \tmpFile tmpHandle -> do
+        hClose tmpHandle
+        populate tmpFile
+        setFileMode tmpFile accessModes
+        renamePath tmpFile newFpName
   pure newFpName
-  where
-    setMode wrapper_fp = setFileMode wrapper_fp accessModes
 
 ------------------------------------------------------------------------------
 -- Utilities
@@ -219,4 +231,3 @@ removeFileIfExists :: FilePath -> IO ()
 removeFileIfExists f = do
   yes <- doesFileExist f
   when yes (removeFile f)
-

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module HIE.Bios.Types where
 
 import           System.Exit
@@ -14,6 +16,7 @@ import           Control.Monad.Trans.Class
 import qualified Control.Monad.Fail as Fail
 #endif
 import           Data.Maybe (fromMaybe)
+import           Data.String
 import qualified Data.Text as T
 import           Prettyprinter
 import           System.Process.Extra (CreateProcess (env, cmdspec), CmdSpec (..), showCommandForUser)
@@ -204,9 +207,13 @@ data LoadMode
   | LoadUnitsFromCradle
   deriving (Eq,Ord,Enum,Bounded,Show)
 
+newtype CacheDir = CacheDir { unCacheDir :: FilePath }
+ deriving (Show, Eq)
+ deriving newtype (IsString)
+
 -- | Configuration for constructing and running a 'Cradle'.
 data CradleRunConfig = CradleRunConfig
-  { cradleCacheDir :: Maybe FilePath
+  { cradleCacheDir :: Maybe CacheDir
   -- ^ Root directory for cache artefacts produced while running the cradle.
   -- 'Nothing' falls back to @$HIE_BIOS_CACHE_DIR@, or the XDG cache
   -- directory if that is unset. See 'resolveCacheDir'.

--- a/src/HIE/Bios/Types.hs
+++ b/src/HIE/Bios/Types.hs
@@ -204,6 +204,17 @@ data LoadMode
   | LoadUnitsFromCradle
   deriving (Eq,Ord,Enum,Bounded,Show)
 
+-- | Configuration for constructing and running a 'Cradle'.
+data CradleRunConfig = CradleRunConfig
+  { cradleCacheDir :: Maybe FilePath
+  -- ^ Root directory for cache artefacts produced while running the cradle.
+  -- 'Nothing' falls back to @$HIE_BIOS_CACHE_DIR@, or the XDG cache
+  -- directory if that is unset. See 'resolveCacheDir'.
+  } deriving (Show, Eq)
+
+defaultCradleRunConfig :: CradleRunConfig
+defaultCradleRunConfig = CradleRunConfig { cradleCacheDir = Nothing }
+
 data CradleAction a = CradleAction {
                         actionName    :: ActionName a
                       -- ^ Name of the action.

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -36,7 +36,7 @@ import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
 import System.IO.Temp
 import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Cradle.Utils (expandGhcOptionResponseFile)
-import HIE.Bios.Environment (extractUnits, getCacheDir)
+import HIE.Bios.Environment (extractUnits, resolveCacheDir)
 import HIE.Bios.Process (cacheFileIn)
 
 
@@ -242,7 +242,7 @@ cabalTestCases extraGhcDep =
       assertCradle isCabalCradle
       root <- askRoot
       buildDir <- liftIO $ do
-        cacheDir <- (fmap CacheDir . makeAbsolute . unCacheDir) =<< getCacheDir ""
+        cacheDir <- resolveCacheDir "" Nothing
         cabalBuildDir cacheDir root
       -- use --multi-repl, as that was the codepath with the bug
       loadFileGhc "B.hs" []

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -36,7 +36,7 @@ import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
 import System.IO.Temp
 import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Cradle.Utils (expandGhcOptionResponseFile)
-import HIE.Bios.Environment (extractUnits)
+import HIE.Bios.Environment (extractUnits, getCacheDir)
 import HIE.Bios.Process (cacheFileIn)
 
 
@@ -241,7 +241,9 @@ cabalTestCases extraGhcDep =
       initCradle "B.hs"
       assertCradle isCabalCradle
       root <- askRoot
-      buildDir <- liftIO $ cabalBuildDir root
+      buildDir <- liftIO $ do
+        cacheDir <- makeAbsolute =<< getCacheDir ""
+        cabalBuildDir cacheDir root
       -- use --multi-repl, as that was the codepath with the bug
       loadFileGhc "B.hs" []
       liftIO $ do
@@ -251,6 +253,16 @@ cabalTestCases extraGhcDep =
         -- Check we are using the correct build directory
         buildDirExists <- doesDirectoryExist buildDir
         assertBool "build dir does not exist" buildDirExists
+  , biosTestCase "custom cache dir" $ runTestEnv "./simple-cabal" $
+      withSystemTempDirectory "hie-bios-custom-cache-dir" $ \cacheRoot -> do
+        initCradleWithConfig defaultCradleRunConfig { cradleCacheDir = Just cacheRoot } "B.hs"
+        assertCradle isCabalCradle
+        loadComponentOptions "B.hs" []
+        _ <- assertLoadSuccess
+        liftIO $ do
+          entries <- listDirectory cacheRoot
+          assertBool ("cache entries under the configured dir: " <> show entries)
+            (any (\e -> "wrapper" `isInfixOf` e || "dist-" `isPrefixOf` e) entries)
   , biosTestCaseAll "nested-cabal" $ runTestEnv "./nested-cabal" $ do
       attemptCabalSingleTargetLoad "sub-comp/Lib.hs"
       mode <- askLoadMode

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -18,7 +18,7 @@ import qualified Test.Tasty.Runners     as Tasty
 import HIE.Bios
 import HIE.Bios.Cradle
 import HIE.Bios.Cradle.Cabal (cabalBuildDir)
-import HIE.Bios.Types (LoadMode(..))
+import HIE.Bios.Types (LoadMode(..), CacheDir (..))
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.Async (replicateConcurrently)
 import Control.Exception (SomeException, evaluate, try)
@@ -158,7 +158,7 @@ cacheFileTests =
               threadDelay 50_000 -- 50ms
               appendFile fp payloadSuffix
         results <- replicateConcurrently 16 $ try @SomeException $ do
-          fp <- cacheFileIn testCacheDir "ghc-pkg" "0123456789abcdef" populate
+          fp <- cacheFileIn (CacheDir testCacheDir) "ghc-pkg" "0123456789abcdef" populate
           contents <- readFile fp
           contents <$ evaluate (length contents)
         forM_ results $ \case
@@ -242,7 +242,7 @@ cabalTestCases extraGhcDep =
       assertCradle isCabalCradle
       root <- askRoot
       buildDir <- liftIO $ do
-        cacheDir <- makeAbsolute =<< getCacheDir ""
+        cacheDir <- (fmap CacheDir . makeAbsolute . unCacheDir) =<< getCacheDir ""
         cabalBuildDir cacheDir root
       -- use --multi-repl, as that was the codepath with the bug
       loadFileGhc "B.hs" []
@@ -255,7 +255,7 @@ cabalTestCases extraGhcDep =
         assertBool "build dir does not exist" buildDirExists
   , biosTestCase "custom cache dir" $ runTestEnv "./simple-cabal" $
       withSystemTempDirectory "hie-bios-custom-cache-dir" $ \cacheRoot -> do
-        initCradleWithConfig defaultCradleRunConfig { cradleCacheDir = Just cacheRoot } "B.hs"
+        initCradleWithConfig defaultCradleRunConfig { cradleCacheDir = Just (CacheDir cacheRoot) } "B.hs"
         assertCradle isCabalCradle
         loadComponentOptions "B.hs" []
         _ <- assertLoadSuccess

--- a/tests/BiosTests.hs
+++ b/tests/BiosTests.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE NumericUnderscores #-}
 module Main (main) where
 
 import Utils
@@ -18,6 +19,9 @@ import HIE.Bios
 import HIE.Bios.Cradle
 import HIE.Bios.Cradle.Cabal (cabalBuildDir)
 import HIE.Bios.Types (LoadMode(..))
+import Control.Concurrent (threadDelay)
+import Control.Concurrent.Async (replicateConcurrently)
+import Control.Exception (SomeException, evaluate, try)
 import Control.Monad (forM_, forM, unless, when)
 import Control.Monad.Extra (unlessM)
 import Control.Monad.IO.Class
@@ -29,9 +33,11 @@ import System.Directory
 import System.FilePath ((</>), makeRelative)
 import System.Info.Extra (isWindows)
 import System.IO (BufferMode (LineBuffering), hSetBuffering, stderr, stdout)
+import System.IO.Temp
 import qualified HIE.Bios.Ghc.Gap as Gap
 import HIE.Bios.Cradle.Utils (expandGhcOptionResponseFile)
 import HIE.Bios.Environment (extractUnits)
+import HIE.Bios.Process (cacheFileIn)
 
 
 argDynamic :: [String]
@@ -81,6 +87,7 @@ main = do
     testGroup "Bios-tests"
       [ testGroup "Find cradle" findCradleTests
       , testGroup "Symlink" symbolicLinkTests
+      , testGroup "Cache files" cacheFileTests
       , testGroup "Loading tests"
         [ testGroup "bios" biosTestCases
         , testGroup "direct" directTestCases
@@ -134,6 +141,29 @@ symbolicLinkTests =
           assertFailure "Test invariant broken, this file must exist."
         loadComponentOptions "./c/A.hs" []
         assertLoadNone
+  ]
+
+-- | Concurrent 'cacheFileIn' calls can race on the same cache entry.
+cacheFileTests :: [TestTree]
+cacheFileTests =
+  [ testCase "cacheFile is atomic under concurrent calls" $ do
+      withSystemTempDirectory "hie-bios-cache-file-test" $ \testCacheDir -> do
+        let payloadPrefix = "#!/bin/sh\n"
+            payloadSuffix = concat (replicate 500 "echo 'cacheFile is atomic under concurrent calls'\n")
+            payload = payloadPrefix <> payloadSuffix
+            -- Pause mid-write so a non-atomic populate would expose a partial
+            -- file, and so all threads pile up on the entry concurrently.
+            populate fp = do
+              writeFile fp payloadPrefix
+              threadDelay 50_000 -- 50ms
+              appendFile fp payloadSuffix
+        results <- replicateConcurrently 16 $ try @SomeException $ do
+          fp <- cacheFileIn testCacheDir "ghc-pkg" "0123456789abcdef" populate
+          contents <- readFile fp
+          contents <$ evaluate (length contents)
+        forM_ results $ \case
+          Left err -> assertFailure $ "cacheFile threw: " <> show err
+          Right contents -> assertEqual "cached file contents" payload contents
   ]
 
 biosTestCases :: [TestTree]

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -355,7 +355,7 @@ loadFileGhc fp extraFps = do
   opts <- assertLoadSuccess
   root <- askRoot
   -- Tests run in parallel, so isolate the interface-file cache per test root.
-  let ifaceCacheRoot = root </> "ghc-iface-cache"
+  let ifaceCacheRoot = CacheDir (root </> "ghc-iface-cache")
   liftIO $
     G.runGhc (Just libdir) $ do
       let (ini, _) = initSessionWithMessage' (Just ifaceCacheRoot) (Just G.batchMsg) opts

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -353,9 +353,12 @@ loadFileGhc fp extraFps = do
   step "Cradle load"
   loadComponentOptions fp extraFps
   opts <- assertLoadSuccess
+  root <- askRoot
+  -- Tests run in parallel, so isolate the interface-file cache per test root.
+  let ifaceCacheRoot = root </> "ghc-iface-cache"
   liftIO $
     G.runGhc (Just libdir) $ do
-      let (ini, _) = initSessionWithMessage' True (Just G.batchMsg) opts
+      let (ini, _) = initSessionWithMessage' (Just ifaceCacheRoot) (Just G.batchMsg) opts
       sf <- ini
       case sf of
         -- Test resetting the targets

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -43,6 +43,7 @@ module Utils (
   relFile,
   findCradleLoc,
   initCradle,
+  initCradleWithConfig,
   initImplicitCradle,
   loadComponentOptions,
   loadRuntimeGhcLibDir,
@@ -287,7 +288,10 @@ findCradleLoc fp = do
   liftIO $ findCradle a_fp
 
 initCradle :: FilePath -> TestM ()
-initCradle fp = do
+initCradle = initCradleWithConfig defaultCradleRunConfig
+
+initCradleWithConfig :: CradleRunConfig -> FilePath -> TestM ()
+initCradleWithConfig config fp = do
   a_fp <- normFile fp
   step $ "Finding Cradle for: " <> fp
   mcfg <- findCradleLoc a_fp
@@ -295,8 +299,8 @@ initCradle fp = do
   step $ "Loading Cradle: " <> show relMcfg
   logger <- askLogger
   crd <- case mcfg of
-    Just cfg -> liftIO $ loadCradle logger cfg
-    Nothing -> liftIO $ loadImplicitCradle logger a_fp
+    Just cfg -> liftIO $ loadCradleWithConfig logger config cfg
+    Nothing -> liftIO $ loadImplicitCradleWithConfig logger config a_fp
   step $ "Cradle: " ++ show crd
   setCradle crd
 


### PR DESCRIPTION
This was mentioned on on Matrix. 

Changes include:

- Adds a `cacheFileIn` that allows varying the cache directory used, overriding the default behavior of using `$XDG_CACHE_HOME`.
- Made the above function thread-safe by using file-locks, and atomic file writes.

As long as downstream consumers were using the `srcHash` parameter as a content addressed tag, I don't think they have to necessarily use `cacheFileIn` and can keep using `cacheFile` as is after this change. I exported `cacheFileIn` mainly for the test I added. 